### PR TITLE
updates for holochain 0.6.1 plus all gets local.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1763938834,
-        "narHash": "sha256-j8iB0Yr4zAvQLueCZ5abxfk6fnG/SJ5JnGUziETjwfg=",
+        "lastModified": 1768873933,
+        "narHash": "sha256-CfyzdaeLNGkyAHp3kT5vjvXhA1pVVK7nyDziYxCPsNk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "d9e753122e51cee64eb8d2dddfe11148f339f5a2",
+        "rev": "0bda7e7d005ccb5522a76d11ccfbf562b71953ca",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "crane_2": {
       "locked": {
-        "lastModified": 1758758545,
-        "narHash": "sha256-NU5WaEdfwF6i8faJ2Yh+jcK9vVFrofLcwlD/mP65JrI=",
+        "lastModified": 1768873933,
+        "narHash": "sha256-CfyzdaeLNGkyAHp3kT5vjvXhA1pVVK7nyDziYxCPsNk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "95d528a5f54eaba0d12102249ce42f4d01f4e364",
+        "rev": "0bda7e7d005ccb5522a76d11ccfbf562b71953ca",
         "type": "github"
       },
       "original": {
@@ -32,11 +32,11 @@
     },
     "crane_3": {
       "locked": {
-        "lastModified": 1758758545,
-        "narHash": "sha256-NU5WaEdfwF6i8faJ2Yh+jcK9vVFrofLcwlD/mP65JrI=",
+        "lastModified": 1768873933,
+        "narHash": "sha256-CfyzdaeLNGkyAHp3kT5vjvXhA1pVVK7nyDziYxCPsNk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "95d528a5f54eaba0d12102249ce42f4d01f4e364",
+        "rev": "0bda7e7d005ccb5522a76d11ccfbf562b71953ca",
         "type": "github"
       },
       "original": {
@@ -50,11 +50,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1763759067,
-        "narHash": "sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q=",
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "2cccadc7357c0ba201788ae99c4dfa90728ef5e0",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
         "type": "github"
       },
       "original": {
@@ -68,11 +68,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1759362264,
-        "narHash": "sha256-wfG0S7pltlYyZTM+qqlhJ7GMw2fTF4mLKCIVhLii/4M=",
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "758cf7296bee11f1706a574c77d072b8a7baa881",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
         "type": "github"
       },
       "original": {
@@ -86,49 +86,32 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1759362264,
-        "narHash": "sha256-wfG0S7pltlYyZTM+qqlhJ7GMw2fTF4mLKCIVhLii/4M=",
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "758cf7296bee11f1706a574c77d072b8a7baa881",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "hc-launch": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1752056054,
-        "narHash": "sha256-iLHhGQXrSfgAibzLSx+mdOQnnTzq4mrRXto7+a+MDLM=",
-        "owner": "holochain",
-        "repo": "hc-launch",
-        "rev": "612aa244ceb4d2136e5adbf181ff0cc123daff65",
-        "type": "github"
-      },
-      "original": {
-        "owner": "holochain",
-        "ref": "holochain-weekly",
-        "repo": "hc-launch",
         "type": "github"
       }
     },
     "hc-scaffold": {
       "flake": false,
       "locked": {
-        "lastModified": 1764163563,
-        "narHash": "sha256-KigJ3h25yNJfeQunPm5QYFPtLSk6nU3IEEvZY8w01Vo=",
+        "lastModified": 1769104114,
+        "narHash": "sha256-Ebh8YW7J4VRAwhK9XQDf98nWAIvciddzdx7LbhZiwdI=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "87e997a7361d4aa7c1bb96261483ebba50223bd0",
+        "rev": "6749c80d54306e4c1ad5831ce2dbdbb9a283ee0c",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.600.1",
+        "ref": "v0.600.1-rc.0",
         "repo": "scaffolding",
         "type": "github"
       }
@@ -136,16 +119,16 @@
     "hc-scaffold_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1764163563,
-        "narHash": "sha256-KigJ3h25yNJfeQunPm5QYFPtLSk6nU3IEEvZY8w01Vo=",
+        "lastModified": 1769104114,
+        "narHash": "sha256-Ebh8YW7J4VRAwhK9XQDf98nWAIvciddzdx7LbhZiwdI=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "87e997a7361d4aa7c1bb96261483ebba50223bd0",
+        "rev": "6749c80d54306e4c1ad5831ce2dbdbb9a283ee0c",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.600.1",
+        "ref": "v0.600.1-rc.0",
         "repo": "scaffolding",
         "type": "github"
       }
@@ -153,16 +136,16 @@
     "hc-scaffold_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1743001074,
-        "narHash": "sha256-FtFGAFY+d6eEP85PkkyhwD2G9fXx4jrQiNjik3Hyqmk=",
+        "lastModified": 1769104114,
+        "narHash": "sha256-Ebh8YW7J4VRAwhK9XQDf98nWAIvciddzdx7LbhZiwdI=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "2ad60188fe6a2bba7b68b414f0d6528967d48400",
+        "rev": "6749c80d54306e4c1ad5831ce2dbdbb9a283ee0c",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-weekly",
+        "ref": "v0.600.1-rc.0",
         "repo": "scaffolding",
         "type": "github"
       }
@@ -170,16 +153,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1763554421,
-        "narHash": "sha256-uCVTHeoJpDcc3Ky6gXt1oZX7XxVL3CmY9pFVQ5AEXtM=",
+        "lastModified": 1769035817,
+        "narHash": "sha256-PVUIsifOy6fRcceBZraLKrPwq83MzRYyfuxDCohv514=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "a6d4e805a0971ccbc0dcb3f3ed6a9e2fac980a3b",
+        "rev": "b499bd881580f9e0dd8f4494aafd4b2093a06168",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.6.0",
+        "ref": "holochain-0.6.1-rc.0",
         "repo": "holochain",
         "type": "github"
       }
@@ -210,11 +193,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760350316,
-        "narHash": "sha256-A9pzCPMXbm8a/Qfr1zOUUH85ST2DH3L3Ew+y77XbOqE=",
+        "lastModified": 1770120172,
+        "narHash": "sha256-GILmDpEkeftimMpgNglmXhhaWR6RnxuzI1TDT0ybJm4=",
         "owner": "darksoil-studio",
         "repo": "holochain-nix-builders",
-        "rev": "f2896026c5d22020f818af0a4c10dc387166ac7f",
+        "rev": "a63d1447f7b60b9c27f9ed09520678ead299a381",
         "type": "github"
       },
       "original": {
@@ -250,11 +233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756904581,
-        "narHash": "sha256-+ZE9swpuBWFhCqwwhLD1A4oGH7IClZLOph4ZHOk1x2U=",
+        "lastModified": 1770120172,
+        "narHash": "sha256-GILmDpEkeftimMpgNglmXhhaWR6RnxuzI1TDT0ybJm4=",
         "owner": "darksoil-studio",
         "repo": "holochain-nix-builders",
-        "rev": "c45b16b19f75d7a9e122ec7afc3ac1769437216b",
+        "rev": "a63d1447f7b60b9c27f9ed09520678ead299a381",
         "type": "github"
       },
       "original": {
@@ -267,16 +250,16 @@
     "holochain_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1763554421,
-        "narHash": "sha256-uCVTHeoJpDcc3Ky6gXt1oZX7XxVL3CmY9pFVQ5AEXtM=",
+        "lastModified": 1769035817,
+        "narHash": "sha256-PVUIsifOy6fRcceBZraLKrPwq83MzRYyfuxDCohv514=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "a6d4e805a0971ccbc0dcb3f3ed6a9e2fac980a3b",
+        "rev": "b499bd881580f9e0dd8f4494aafd4b2093a06168",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.6.0",
+        "ref": "holochain-0.6.1-rc.0",
         "repo": "holochain",
         "type": "github"
       }
@@ -284,16 +267,16 @@
     "holochain_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1759884228,
-        "narHash": "sha256-T78qKjwfqb7g7if23N5suotGqnPPxMGsH72pzc/KHM8=",
+        "lastModified": 1769035817,
+        "narHash": "sha256-PVUIsifOy6fRcceBZraLKrPwq83MzRYyfuxDCohv514=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "799be91c8122c3767d55b8c2f0abf13129a6212b",
+        "rev": "b499bd881580f9e0dd8f4494aafd4b2093a06168",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.6.0-dev.28",
+        "ref": "holochain-0.6.1-rc.0",
         "repo": "holochain",
         "type": "github"
       }
@@ -307,15 +290,14 @@
         "kitsune2": "kitsune2",
         "lair-keystore": "lair-keystore",
         "nixpkgs": "nixpkgs",
-        "playground": "playground",
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1764604731,
-        "narHash": "sha256-IW9tFLUMqoaIAfAU9eH7wL7ws93nf+gEhl2v9Aipzak=",
+        "lastModified": 1769121828,
+        "narHash": "sha256-o1GUUg9FUADcTOU4gzDDtiuJo61PyrQHCn0e64HRJYU=",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "2fec8bf3772bf0df6f37734da3e063b9aa285aca",
+        "rev": "3e2a4b96b177aaaa233fd744ba82bfe308e85635",
         "type": "github"
       },
       "original": {
@@ -334,15 +316,14 @@
         "kitsune2": "kitsune2_2",
         "lair-keystore": "lair-keystore_2",
         "nixpkgs": "nixpkgs_2",
-        "playground": "playground_2",
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1764604731,
-        "narHash": "sha256-IW9tFLUMqoaIAfAU9eH7wL7ws93nf+gEhl2v9Aipzak=",
+        "lastModified": 1769121828,
+        "narHash": "sha256-o1GUUg9FUADcTOU4gzDDtiuJo61PyrQHCn0e64HRJYU=",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "2fec8bf3772bf0df6f37734da3e063b9aa285aca",
+        "rev": "3e2a4b96b177aaaa233fd744ba82bfe308e85635",
         "type": "github"
       },
       "original": {
@@ -356,26 +337,24 @@
       "inputs": {
         "crane": "crane_3",
         "flake-parts": "flake-parts_3",
-        "hc-launch": "hc-launch",
         "hc-scaffold": "hc-scaffold_3",
         "holochain": "holochain_3",
         "kitsune2": "kitsune2_3",
         "lair-keystore": "lair-keystore_3",
         "nixpkgs": "nixpkgs_3",
-        "playground": "playground_3",
         "rust-overlay": "rust-overlay_3"
       },
       "locked": {
-        "lastModified": 1759961726,
-        "narHash": "sha256-1TYjgyp8kbn9bwj8LbQLGhtR+XedJRNuAE7GsRDQn1s=",
+        "lastModified": 1769121828,
+        "narHash": "sha256-o1GUUg9FUADcTOU4gzDDtiuJo61PyrQHCn0e64HRJYU=",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "81345a6c742a646fb160a2341ced4eb0a9ca9f84",
+        "rev": "3e2a4b96b177aaaa233fd744ba82bfe308e85635",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "main",
+        "ref": "main-0.6",
         "repo": "holonix",
         "type": "github"
       }
@@ -383,16 +362,16 @@
     "kitsune2": {
       "flake": false,
       "locked": {
-        "lastModified": 1763403287,
-        "narHash": "sha256-dqQJMoDbcD0ekttrv5+8ph5Yf25EdXwKktsxNjV57Iw=",
+        "lastModified": 1768402558,
+        "narHash": "sha256-v7uEmcVGC6tDjrkEZHMJa9DdXnqXwwVxJx9GkZq9P/U=",
         "owner": "holochain",
         "repo": "kitsune2",
-        "rev": "22de6e42100aa960d05f5f30427a236ad922bd80",
+        "rev": "2b809bcf0bff3d493cd5ba230677240432fff58a",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.3.2",
+        "ref": "2b809bcf0bff3d493cd5ba230677240432fff58a",
         "repo": "kitsune2",
         "type": "github"
       }
@@ -400,16 +379,16 @@
     "kitsune2_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1763403287,
-        "narHash": "sha256-dqQJMoDbcD0ekttrv5+8ph5Yf25EdXwKktsxNjV57Iw=",
+        "lastModified": 1768402558,
+        "narHash": "sha256-v7uEmcVGC6tDjrkEZHMJa9DdXnqXwwVxJx9GkZq9P/U=",
         "owner": "holochain",
         "repo": "kitsune2",
-        "rev": "22de6e42100aa960d05f5f30427a236ad922bd80",
+        "rev": "2b809bcf0bff3d493cd5ba230677240432fff58a",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.3.2",
+        "ref": "2b809bcf0bff3d493cd5ba230677240432fff58a",
         "repo": "kitsune2",
         "type": "github"
       }
@@ -417,16 +396,16 @@
     "kitsune2_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1751453889,
-        "narHash": "sha256-U0iB9rhYWLoie9i/L3vASZyUHUQNukyPlvkIe79prTU=",
+        "lastModified": 1768402558,
+        "narHash": "sha256-v7uEmcVGC6tDjrkEZHMJa9DdXnqXwwVxJx9GkZq9P/U=",
         "owner": "holochain",
         "repo": "kitsune2",
-        "rev": "d260ba4b3c9be0481d754876c501d08e76a3a45b",
+        "rev": "2b809bcf0bff3d493cd5ba230677240432fff58a",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "v0.2.11",
+        "ref": "2b809bcf0bff3d493cd5ba230677240432fff58a",
         "repo": "kitsune2",
         "type": "github"
       }
@@ -484,27 +463,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763948260,
-        "narHash": "sha256-dY9qLD0H0zOUgU3vWacPY6Qc421BeQAfm8kBuBtPVE0=",
+        "lastModified": 1768940263,
+        "narHash": "sha256-sJERJIYTKPFXkoz/gBaBtRKke82h4DkX3BBSsKbfbvI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1c8ba8d3f7634acac4a2094eef7c32ad9106532c",
+        "rev": "3ceaaa8bc963ced4d830e06ea2d0863b6490ff03",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1761765539,
-        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
         "type": "github"
       },
       "original": {
@@ -515,11 +494,11 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1754788789,
-        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
         "type": "github"
       },
       "original": {
@@ -530,11 +509,11 @@
     },
     "nixpkgs-lib_3": {
       "locked": {
-        "lastModified": 1754788789,
-        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
         "type": "github"
       },
       "original": {
@@ -545,32 +524,32 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1759281824,
-        "narHash": "sha256-FIBE1qXv9TKvSNwst6FumyHwCRH3BlWDpfsnqRDCll0=",
+        "lastModified": 1768940263,
+        "narHash": "sha256-sJERJIYTKPFXkoz/gBaBtRKke82h4DkX3BBSsKbfbvI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5b5be50345d4113d04ba58c444348849f5585b4a",
+        "rev": "3ceaaa8bc963ced4d830e06ea2d0863b6490ff03",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1759281824,
-        "narHash": "sha256-FIBE1qXv9TKvSNwst6FumyHwCRH3BlWDpfsnqRDCll0=",
+        "lastModified": 1768940263,
+        "narHash": "sha256-sJERJIYTKPFXkoz/gBaBtRKke82h4DkX3BBSsKbfbvI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5b5be50345d4113d04ba58c444348849f5585b4a",
+        "rev": "3ceaaa8bc963ced4d830e06ea2d0863b6490ff03",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -594,72 +573,20 @@
           "holonix",
           "rust-overlay"
         ],
-        "scaffolding": "scaffolding",
-        "webkitnixpkgs": "webkitnixpkgs"
+        "scaffolding": "scaffolding"
       },
       "locked": {
-        "lastModified": 1765397287,
-        "narHash": "sha256-gPkHHmA84XdRI/1g64fL9XeUWvYOFJChdqRXEsiNpnk=",
+        "lastModified": 1770121713,
+        "narHash": "sha256-yPkdH7CYvkE0D1P+l6QMLkzScJVBy+OdP480cGNGxqY=",
         "owner": "darksoil-studio",
         "repo": "tauri-plugin-holochain",
-        "rev": "cc1502d4562ff5b84f04413fc69fce1a43b9960b",
+        "rev": "9bb4fcbdf395c57eeedb713203ecad639ae91b54",
         "type": "github"
       },
       "original": {
         "owner": "darksoil-studio",
         "ref": "main-0.6",
         "repo": "tauri-plugin-holochain",
-        "type": "github"
-      }
-    },
-    "playground": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1756729856,
-        "narHash": "sha256-xJnIfcIyLRTXsf+N8OOMnqzRkx2gT/DSta7qCm8yU7Y=",
-        "owner": "darksoil-studio",
-        "repo": "holochain-playground",
-        "rev": "5e858641de8ac6113cfa6b47ea1350762a629a61",
-        "type": "github"
-      },
-      "original": {
-        "owner": "darksoil-studio",
-        "ref": "main",
-        "repo": "holochain-playground",
-        "type": "github"
-      }
-    },
-    "playground_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1756729856,
-        "narHash": "sha256-xJnIfcIyLRTXsf+N8OOMnqzRkx2gT/DSta7qCm8yU7Y=",
-        "owner": "darksoil-studio",
-        "repo": "holochain-playground",
-        "rev": "5e858641de8ac6113cfa6b47ea1350762a629a61",
-        "type": "github"
-      },
-      "original": {
-        "owner": "darksoil-studio",
-        "ref": "main",
-        "repo": "holochain-playground",
-        "type": "github"
-      }
-    },
-    "playground_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1756729856,
-        "narHash": "sha256-xJnIfcIyLRTXsf+N8OOMnqzRkx2gT/DSta7qCm8yU7Y=",
-        "owner": "darksoil-studio",
-        "repo": "holochain-playground",
-        "rev": "5e858641de8ac6113cfa6b47ea1350762a629a61",
-        "type": "github"
-      },
-      "original": {
-        "owner": "darksoil-studio",
-        "ref": "main",
-        "repo": "holochain-playground",
         "type": "github"
       }
     },
@@ -682,11 +609,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764297505,
-        "narHash": "sha256-qrLpVu2/hA9Cu6IovMEsgh9YRyvmmWS+bSx7C1JGChA=",
+        "lastModified": 1768963622,
+        "narHash": "sha256-n6VHiUgrYD9yjagzG6ncVVqFbVTsKCI54tR9PNAFCo0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9623580f8ce09ec444b9aca107566ec5db110e62",
+        "rev": "2ef5b3362af585a83bafd34e7fc9b1f388c2e5e2",
         "type": "github"
       },
       "original": {
@@ -704,11 +631,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759372351,
-        "narHash": "sha256-kULiC2oMMuyaO92gPiu+6XBfeXuFcXaauwo0tXAwXdQ=",
+        "lastModified": 1768963622,
+        "narHash": "sha256-n6VHiUgrYD9yjagzG6ncVVqFbVTsKCI54tR9PNAFCo0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7ef14552303de7128662666f9a71342099ffc725",
+        "rev": "2ef5b3362af585a83bafd34e7fc9b1f388c2e5e2",
         "type": "github"
       },
       "original": {
@@ -726,11 +653,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759372351,
-        "narHash": "sha256-kULiC2oMMuyaO92gPiu+6XBfeXuFcXaauwo0tXAwXdQ=",
+        "lastModified": 1768963622,
+        "narHash": "sha256-n6VHiUgrYD9yjagzG6ncVVqFbVTsKCI54tR9PNAFCo0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7ef14552303de7128662666f9a71342099ffc725",
+        "rev": "2ef5b3362af585a83bafd34e7fc9b1f388c2e5e2",
         "type": "github"
       },
       "original": {
@@ -769,11 +696,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760350311,
-        "narHash": "sha256-wYg0nkd0/+VlU5Pl2IzNsXG5ygPtXKsNj2c0jXcpKQ8=",
+        "lastModified": 1770121204,
+        "narHash": "sha256-meHpdtUg1mPn+/FzJpulcdyoUKIaLP8LzDsOW5x/2gY=",
         "owner": "darksoil-studio",
         "repo": "scaffolding",
-        "rev": "b4ce7a036a1a8d31280d93c9c9a0dc1d39bbfe7f",
+        "rev": "f601d7f7c56ac485885f21a15d115f07d4794373",
         "type": "github"
       },
       "original": {
@@ -804,33 +731,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1760350631,
-        "narHash": "sha256-9BPi0yqM52kay7eHsBrXgMfbuqOBNz6AhziUC4bsowU=",
+        "lastModified": 1770121204,
+        "narHash": "sha256-meHpdtUg1mPn+/FzJpulcdyoUKIaLP8LzDsOW5x/2gY=",
         "owner": "darksoil-studio",
         "repo": "scaffolding",
-        "rev": "825f3a7745e809a54f1f9a36550ab2dffb41d6e0",
+        "rev": "f601d7f7c56ac485885f21a15d115f07d4794373",
         "type": "github"
       },
       "original": {
         "owner": "darksoil-studio",
         "ref": "main-0.6",
         "repo": "scaffolding",
-        "type": "github"
-      }
-    },
-    "webkitnixpkgs": {
-      "locked": {
-        "lastModified": 1709246466,
-        "narHash": "sha256-jN8Y5Zv2tNUKIGuSqhm8yIMn2x6jhMQvNwKYduvKxjU=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "ed4db9c6c75079ff3570a9e3eb6806c8f692dc26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "ed4db9c6c75079ff3570a9e3eb6806c8f692dc26",
         "type": "github"
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "ui"
       ],
       "devDependencies": {
-        "@holochain/hc-spin": "^0.600.0",
+        "@holochain/hc-spin": "^0.600.2-rc.0",
         "@tauri-apps/cli": "^2.5.0",
         "@tsconfig/svelte": "^5.0.4",
         "@types/dompurify": "^3.0.5",
@@ -808,12 +808,12 @@
       "integrity": "sha512-Dn5pTV/m3XaK1Zvq3liw/vQUt7goM7Y84x2zUyH8cb9CNMs4kPCNHs3kalbJZ/ymzFvwcdiLwwNW8AKk+WWN5A=="
     },
     "node_modules/@holochain-open-dev/elements": {
-      "version": "0.600.0",
-      "resolved": "https://registry.npmjs.org/@holochain-open-dev/elements/-/elements-0.600.0.tgz",
-      "integrity": "sha512-fzWIqDj8InG/jv/xb00LFYQJjXZa7pdwY3fHRmCQICbPPKibUF/sBgr60TbE3gxPsXjzX5p7ffBt1dW2p3AfBw==",
+      "version": "0.601.0",
+      "resolved": "https://registry.npmjs.org/@holochain-open-dev/elements/-/elements-0.601.0.tgz",
+      "integrity": "sha512-a4cyNdV6YlsrMZSIUEdyC/V6dXrdJdOfql250SZE64vKJxmfHSrebYMIlzTaf3HKZoPaMOlxbfsvWqk1sDf1sg==",
       "dependencies": {
         "@holo-host/identicon": "^0.1.0",
-        "@holochain/client": "^0.20.0",
+        "@holochain/client": "=0.20.4-rc.0",
         "@lit/localize": "^0.12.0",
         "@mdi/js": "^7.1.96",
         "@shoelace-style/shoelace": "^2.20.0",
@@ -824,30 +824,56 @@
         "prosemirror-view": "^1.31.3"
       }
     },
-    "node_modules/@holochain-open-dev/file-storage": {
-      "version": "0.600.0-dev.0",
-      "resolved": "https://registry.npmjs.org/@holochain-open-dev/file-storage/-/file-storage-0.600.0-dev.0.tgz",
-      "integrity": "sha512-eR9xCHqM7JY1+aBwvgOHpNltqurfF0QsA1wLUrjB/wkPFwujbV9PwYGya44seTR2sWPn97Fg+sDhNohF157wzQ==",
-      "license": "MIT",
+    "node_modules/@holochain-open-dev/elements/node_modules/@holochain/client": {
+      "version": "0.20.4-rc.0",
+      "resolved": "https://registry.npmjs.org/@holochain/client/-/client-0.20.4-rc.0.tgz",
+      "integrity": "sha512-vE+RZKbn9t+3pRYQaxAiK0UFkHxDmYZgsD17XhlTkBhF3RvzjMFFgkKJzsx3Y5Jq+TiVXrm1+eGBm4F8KVzdGQ==",
+      "license": "CAL-1.0",
       "dependencies": {
-        "@holochain-open-dev/elements": "^0.600.0-dev.0",
-        "@holochain-open-dev/utils": "^0.600.0-dev.0",
-        "@holochain/client": "^0.20.0-dev.2",
-        "@lit-labs/task": "^2.0.0",
-        "@lit/context": "^1.0.0",
-        "@lit/localize": "^0.12.0",
-        "@scoped-elements/dropzone": "^0.2.1",
-        "@shoelace-style/shoelace": "^2.11.0",
-        "idb-keyval": "^6.2.1",
-        "lit": "^3.0.0"
+        "@bitgo/blake2b": "^3.2.4",
+        "@msgpack/msgpack": "^3.1.2",
+        "emittery": "^1.2.0",
+        "isomorphic-ws": "^5.0.0",
+        "js-base64": "^3.7.8",
+        "js-sha512": "^0.9.0",
+        "libsodium-wrappers": "^0.8",
+        "lodash-es": "^4.17.21",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=18.0.0 || >=20.0.0 || >= 22.0.0"
+      }
+    },
+    "node_modules/@holochain-open-dev/elements/node_modules/@msgpack/msgpack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@holochain-open-dev/elements/node_modules/libsodium": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.8.2.tgz",
+      "integrity": "sha512-TsnGYMoZtpweT+kR+lOv5TVsnJ/9U0FZOsLFzFOMWmxqOAYXjX3fsrPAW+i1LthgDKXJnI9A8dWEanT1tnJKIw==",
+      "license": "ISC"
+    },
+    "node_modules/@holochain-open-dev/elements/node_modules/libsodium-wrappers": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.8.2.tgz",
+      "integrity": "sha512-VFLmfxkxo+U9q60tjcnSomQBRx2UzlRjKWJqvB4K1pUqsMQg4cu3QXA2nrcsj9A1qRsnJBbi2Ozx1hsiDoCkhw==",
+      "license": "ISC",
+      "dependencies": {
+        "libsodium": "^0.8.0"
       }
     },
     "node_modules/@holochain-open-dev/utils": {
-      "version": "0.600.0",
-      "resolved": "https://registry.npmjs.org/@holochain-open-dev/utils/-/utils-0.600.0.tgz",
-      "integrity": "sha512-zc/eF1cvVZvumBjLdY/FHZdWO/ICRR95bAM03dnCAhoWs4psIe+HCdMK+mq2u/KV7lXYQU5gKUF+WyUNaB0PFA==",
+      "version": "0.601.0",
+      "resolved": "https://registry.npmjs.org/@holochain-open-dev/utils/-/utils-0.601.0.tgz",
+      "integrity": "sha512-y6gKoPbYGp4U9UHI3ZttcEnp97JAIT2XdQOuDgT6tJMKORdhXP88e5FxV+P2tArby127+DnRYvW2fenydZAJdw==",
       "dependencies": {
-        "@holochain/client": "^0.20.0",
+        "@holochain/client": "=0.20.4-rc.0",
         "@msgpack/msgpack": "^2.8.0",
         "blakejs": "^1.2.1",
         "emittery": "^1.0.1",
@@ -855,10 +881,55 @@
         "sort-keys": "^5.0.0"
       }
     },
+    "node_modules/@holochain-open-dev/utils/node_modules/@holochain/client": {
+      "version": "0.20.4-rc.0",
+      "resolved": "https://registry.npmjs.org/@holochain/client/-/client-0.20.4-rc.0.tgz",
+      "integrity": "sha512-vE+RZKbn9t+3pRYQaxAiK0UFkHxDmYZgsD17XhlTkBhF3RvzjMFFgkKJzsx3Y5Jq+TiVXrm1+eGBm4F8KVzdGQ==",
+      "license": "CAL-1.0",
+      "dependencies": {
+        "@bitgo/blake2b": "^3.2.4",
+        "@msgpack/msgpack": "^3.1.2",
+        "emittery": "^1.2.0",
+        "isomorphic-ws": "^5.0.0",
+        "js-base64": "^3.7.8",
+        "js-sha512": "^0.9.0",
+        "libsodium-wrappers": "^0.8",
+        "lodash-es": "^4.17.21",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=18.0.0 || >=20.0.0 || >= 22.0.0"
+      }
+    },
+    "node_modules/@holochain-open-dev/utils/node_modules/@holochain/client/node_modules/@msgpack/msgpack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@holochain-open-dev/utils/node_modules/libsodium": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.8.2.tgz",
+      "integrity": "sha512-TsnGYMoZtpweT+kR+lOv5TVsnJ/9U0FZOsLFzFOMWmxqOAYXjX3fsrPAW+i1LthgDKXJnI9A8dWEanT1tnJKIw==",
+      "license": "ISC"
+    },
+    "node_modules/@holochain-open-dev/utils/node_modules/libsodium-wrappers": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.8.2.tgz",
+      "integrity": "sha512-VFLmfxkxo+U9q60tjcnSomQBRx2UzlRjKWJqvB4K1pUqsMQg4cu3QXA2nrcsj9A1qRsnJBbi2Ozx1hsiDoCkhw==",
+      "license": "ISC",
+      "dependencies": {
+        "libsodium": "^0.8.0"
+      }
+    },
     "node_modules/@holochain/client": {
       "version": "0.20.1",
       "resolved": "https://registry.npmjs.org/@holochain/client/-/client-0.20.1.tgz",
       "integrity": "sha512-PG9x8UgOiQH5nMIVBG+YiZ1wX4sIv9/aAd9LUV2bkGojh3bXyyHD3dZ2B2hzZiOHU8p1gwPSi0N/rCb0WZr0hQ==",
+      "dev": true,
       "license": "CAL-1.0",
       "dependencies": {
         "@bitgo/blake2b": "^3.2.4",
@@ -879,22 +950,23 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.2.tgz",
       "integrity": "sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@holochain/hc-spin": {
-      "version": "0.600.0",
-      "resolved": "https://registry.npmjs.org/@holochain/hc-spin/-/hc-spin-0.600.0.tgz",
-      "integrity": "sha512-dG2Ics7lgYkVb1AxUOgFR45xLkK2xus7i7/orQnteDI9j7egGcFRHq7u9qkFW5AQAP9RFiLX7Z+lZxek2ZajUQ==",
+      "version": "0.600.2-rc.0",
+      "resolved": "https://registry.npmjs.org/@holochain/hc-spin/-/hc-spin-0.600.2-rc.0.tgz",
+      "integrity": "sha512-TNuIpFcZHh4jfrgoaZZZW3kjJ6CPx4K4aiuUueZqw3EDJNa2mXXUvJSujLXD7pMDxlD2qhT0T0zCAJOpkpGm/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.0",
         "@electron-toolkit/utils": "^3.0.0",
         "@holochain/client": "^0.20.0",
-        "@holochain/hc-spin-rust-utils": "0.600.0",
+        "@holochain/hc-spin-rust-utils": "0.601.1-rc.0",
         "@msgpack/msgpack": "^2.8.0",
         "bufferutil": "4.0.8",
         "commander": "11.1.0",
@@ -910,26 +982,26 @@
       }
     },
     "node_modules/@holochain/hc-spin-rust-utils": {
-      "version": "0.600.0",
-      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils/-/hc-spin-rust-utils-0.600.0.tgz",
-      "integrity": "sha512-gseESyOrnoht22WsrZzfi/gR3jwgtypw3gErqDL8jYD5tYuqo0ibXZwDvmCBSAWDSxc1ZSWGRsWH09ZvxxAeDw==",
+      "version": "0.601.1-rc.0",
+      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils/-/hc-spin-rust-utils-0.601.1-rc.0.tgz",
+      "integrity": "sha512-3mLtCf1bvUW+/lzGEthDjhPXknzaDU9vUXkX10HCwgee6jDo8GF4W/uMOjeNFIp7ucmO9VM8fvJPUc4Hn1YZlw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@holochain/hc-spin-rust-utils-darwin-arm64": "0.600.0",
-        "@holochain/hc-spin-rust-utils-darwin-x64": "0.600.0",
-        "@holochain/hc-spin-rust-utils-linux-arm64-gnu": "0.600.0",
-        "@holochain/hc-spin-rust-utils-linux-x64-gnu": "0.600.0",
-        "@holochain/hc-spin-rust-utils-win32-x64-msvc": "0.600.0"
+        "@holochain/hc-spin-rust-utils-darwin-arm64": "0.601.1-rc.0",
+        "@holochain/hc-spin-rust-utils-darwin-x64": "0.601.1-rc.0",
+        "@holochain/hc-spin-rust-utils-linux-arm64-gnu": "0.601.1-rc.0",
+        "@holochain/hc-spin-rust-utils-linux-x64-gnu": "0.601.1-rc.0",
+        "@holochain/hc-spin-rust-utils-win32-x64-msvc": "0.601.1-rc.0"
       }
     },
     "node_modules/@holochain/hc-spin-rust-utils-darwin-arm64": {
-      "version": "0.600.0",
-      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-darwin-arm64/-/hc-spin-rust-utils-darwin-arm64-0.600.0.tgz",
-      "integrity": "sha512-tvU5vBHkkGRSD9K+3HWkTySX7XK+vdD35x3x/4pQ5J/31gRMKcRbrP0W1n7mTOyFUWQjgNHnLJeTM3yt2a7tbA==",
+      "version": "0.601.1-rc.0",
+      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-darwin-arm64/-/hc-spin-rust-utils-darwin-arm64-0.601.1-rc.0.tgz",
+      "integrity": "sha512-usn6iZUamnOgh+bsdPOWDw9hCEy5SOgz5zftLgwvVv0n9KpMYxx23OfMeLBqNteBQjxBqYzV5oUDKNFPKY2UKA==",
       "cpu": [
         "arm64"
       ],
@@ -944,9 +1016,9 @@
       }
     },
     "node_modules/@holochain/hc-spin-rust-utils-darwin-x64": {
-      "version": "0.600.0",
-      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-darwin-x64/-/hc-spin-rust-utils-darwin-x64-0.600.0.tgz",
-      "integrity": "sha512-Mewfh8JC49/kXMRNT4Y+ObwrjNk0FTN9aOrStsmRVXfvb4naCRnuExfz3X8iMB85b6SBPxc0lyCC9A4YGvUFPw==",
+      "version": "0.601.1-rc.0",
+      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-darwin-x64/-/hc-spin-rust-utils-darwin-x64-0.601.1-rc.0.tgz",
+      "integrity": "sha512-USqENFPjuZ4E8vGVnJg8dyb3V9TcC9OLagjeKe68VLeFlCZiFkse7OIVpeiTn0yRjcmiTitj/XgJqMS5K4TCIQ==",
       "cpu": [
         "x64"
       ],
@@ -961,9 +1033,9 @@
       }
     },
     "node_modules/@holochain/hc-spin-rust-utils-linux-arm64-gnu": {
-      "version": "0.600.0",
-      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-linux-arm64-gnu/-/hc-spin-rust-utils-linux-arm64-gnu-0.600.0.tgz",
-      "integrity": "sha512-o/RGxy+2hvvN5S8OnVnOLQyx9uiwT2tBSnGbyYZHkZTzipi9eVczOlLlNQnck3s3ApxwAv+FP7dDLJBVxZjmRA==",
+      "version": "0.601.1-rc.0",
+      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-linux-arm64-gnu/-/hc-spin-rust-utils-linux-arm64-gnu-0.601.1-rc.0.tgz",
+      "integrity": "sha512-hjUqEzsdUi1agcpvDx2Q8yWxUXEyTR3N9B7UV3IkKDxsTqq1I/bXv4XPvU2Yv02q0xOoFy0FGRNqfdGvf32F7Q==",
       "cpu": [
         "arm64"
       ],
@@ -978,9 +1050,9 @@
       }
     },
     "node_modules/@holochain/hc-spin-rust-utils-linux-x64-gnu": {
-      "version": "0.600.0",
-      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-linux-x64-gnu/-/hc-spin-rust-utils-linux-x64-gnu-0.600.0.tgz",
-      "integrity": "sha512-nr2prm4tlB3inRnQANc6W2M/8JleBTWbleSJ4tdFmS0U2xjoKBLGYmp6TjeTwLAod/99qCNiYoVFblQhxWcZ4w==",
+      "version": "0.601.1-rc.0",
+      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-linux-x64-gnu/-/hc-spin-rust-utils-linux-x64-gnu-0.601.1-rc.0.tgz",
+      "integrity": "sha512-GxxRJKJQfLqgeMAaRTKFwFmPqsw/uxy8UUnnTklMbU+nCdY7a1NJes+UXw0LPR9jCevVoY5cORdYi5IKsXPnuA==",
       "cpu": [
         "x64"
       ],
@@ -995,9 +1067,9 @@
       }
     },
     "node_modules/@holochain/hc-spin-rust-utils-win32-x64-msvc": {
-      "version": "0.600.0",
-      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-win32-x64-msvc/-/hc-spin-rust-utils-win32-x64-msvc-0.600.0.tgz",
-      "integrity": "sha512-RRyyN+51o7E8TuaKtS3xTAOyh2vVa39dhvY7Tr9EQLxSI9EO1xn4nM+3ZYqSCKPiSUlZ44DwOSrwgmbm2o/9xg==",
+      "version": "0.601.1-rc.0",
+      "resolved": "https://registry.npmjs.org/@holochain/hc-spin-rust-utils-win32-x64-msvc/-/hc-spin-rust-utils-win32-x64-msvc-0.601.1-rc.0.tgz",
+      "integrity": "sha512-MaXC306ha/SwQODmQwaxxbDgd61L2tX8JGVP6hYxsajdqsrvqM42EfjuhYhqXwZi0ktR6+uLEdiJSqSawj3nYw==",
       "cpu": [
         "x64"
       ],
@@ -3314,7 +3386,8 @@
     "node_modules/blakejs": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
-      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "license": "MIT"
     },
     "node_modules/boolean": {
       "version": "3.2.0",
@@ -5789,12 +5862,14 @@
     "node_modules/libsodium": {
       "version": "0.7.15",
       "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.15.tgz",
-      "integrity": "sha512-sZwRknt/tUpE2AwzHq3jEyUU5uvIZHtSssktXq7owd++3CSgn8RGrv6UZJJBpP7+iBghBqe7Z06/2M31rI2NKw=="
+      "integrity": "sha512-sZwRknt/tUpE2AwzHq3jEyUU5uvIZHtSssktXq7owd++3CSgn8RGrv6UZJJBpP7+iBghBqe7Z06/2M31rI2NKw==",
+      "dev": true
     },
     "node_modules/libsodium-wrappers": {
       "version": "0.7.15",
       "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.15.tgz",
       "integrity": "sha512-E4anqJQwcfiC6+Yrl01C1m8p99wEhLmJSs0VQqST66SbQXXBoaJY0pF4BNjRYa/sOQAxx6lXAaAFIlx+15tXJQ==",
+      "dev": true,
       "dependencies": {
         "libsodium": "^0.7.15"
       }
@@ -7709,6 +7784,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-5.1.0.tgz",
       "integrity": "sha512-aSbHV0DaBcr7u0PVHXzM6NbZNAtrr9sF6+Qfs9UUVG7Ll3jQ6hHi8F/xqIIcn2rvIVbr0v/2zyjSdwSV47AgLQ==",
+      "license": "MIT",
       "dependencies": {
         "is-plain-obj": "^4.0.0"
       },
@@ -7747,6 +7823,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -9033,10 +9110,10 @@
       "version": "0.11.0",
       "dependencies": {
         "@buildyourwebapp/tauri-plugin-sharesheet": "0.0.1",
-        "@holochain-open-dev/elements": "^0.600.0",
+        "@holochain-open-dev/elements": "^0.601.0",
         "@holochain-open-dev/file-storage": "^0.600.0-dev.0",
-        "@holochain-open-dev/utils": "^0.600.0",
-        "@holochain/client": "^0.20.1",
+        "@holochain-open-dev/utils": "^0.601.0",
+        "@holochain/client": "0.20.4-rc.0",
         "@msgpack/msgpack": "^3.1.2",
         "@svelte-put/clickoutside": "^3.0.2",
         "@tanstack/svelte-virtual": "^3.13.0",
@@ -9103,6 +9180,103 @@
         "vite-plugin-tailwind-purgecss": "^0.3.3"
       }
     },
+    "ui/node_modules/@holochain-open-dev/file-storage": {
+      "version": "0.600.0-dev.0",
+      "resolved": "https://registry.npmjs.org/@holochain-open-dev/file-storage/-/file-storage-0.600.0-dev.0.tgz",
+      "integrity": "sha512-eR9xCHqM7JY1+aBwvgOHpNltqurfF0QsA1wLUrjB/wkPFwujbV9PwYGya44seTR2sWPn97Fg+sDhNohF157wzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@holochain-open-dev/elements": "^0.600.0-dev.0",
+        "@holochain-open-dev/utils": "^0.600.0-dev.0",
+        "@holochain/client": "^0.20.0-dev.2",
+        "@lit-labs/task": "^2.0.0",
+        "@lit/context": "^1.0.0",
+        "@lit/localize": "^0.12.0",
+        "@scoped-elements/dropzone": "^0.2.1",
+        "@shoelace-style/shoelace": "^2.11.0",
+        "idb-keyval": "^6.2.1",
+        "lit": "^3.0.0"
+      }
+    },
+    "ui/node_modules/@holochain-open-dev/file-storage/node_modules/@holochain-open-dev/elements": {
+      "version": "0.600.0",
+      "resolved": "https://registry.npmjs.org/@holochain-open-dev/elements/-/elements-0.600.0.tgz",
+      "integrity": "sha512-fzWIqDj8InG/jv/xb00LFYQJjXZa7pdwY3fHRmCQICbPPKibUF/sBgr60TbE3gxPsXjzX5p7ffBt1dW2p3AfBw==",
+      "dependencies": {
+        "@holo-host/identicon": "^0.1.0",
+        "@holochain/client": "^0.20.0",
+        "@lit/localize": "^0.12.0",
+        "@mdi/js": "^7.1.96",
+        "@shoelace-style/shoelace": "^2.20.0",
+        "lit": "^3.0.2",
+        "prosemirror-commands": "^1.5.2",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-view": "^1.31.3"
+      }
+    },
+    "ui/node_modules/@holochain-open-dev/file-storage/node_modules/@holochain-open-dev/utils": {
+      "version": "0.600.0",
+      "resolved": "https://registry.npmjs.org/@holochain-open-dev/utils/-/utils-0.600.0.tgz",
+      "integrity": "sha512-zc/eF1cvVZvumBjLdY/FHZdWO/ICRR95bAM03dnCAhoWs4psIe+HCdMK+mq2u/KV7lXYQU5gKUF+WyUNaB0PFA==",
+      "dependencies": {
+        "@holochain/client": "^0.20.0",
+        "@msgpack/msgpack": "^2.8.0",
+        "blakejs": "^1.2.1",
+        "emittery": "^1.0.1",
+        "lodash-es": "^4.17.21",
+        "sort-keys": "^5.0.0"
+      }
+    },
+    "ui/node_modules/@holochain-open-dev/file-storage/node_modules/@holochain-open-dev/utils/node_modules/@msgpack/msgpack": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
+      "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "ui/node_modules/@holochain-open-dev/file-storage/node_modules/@holochain/client": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@holochain/client/-/client-0.20.2.tgz",
+      "integrity": "sha512-vT3/NfVXizjtGxj1NZeThaNoM1OvT5OXh7qtYVyppj/PRf5bRzC0q4M5xMrMEKFd6FzVvn4qEGXCr/MV9xHL1g==",
+      "license": "CAL-1.0",
+      "dependencies": {
+        "@bitgo/blake2b": "^3.2.4",
+        "@msgpack/msgpack": "^3.1.2",
+        "emittery": "^1.2.0",
+        "isomorphic-ws": "^5.0.0",
+        "js-base64": "^3.7.8",
+        "js-sha512": "^0.9.0",
+        "libsodium-wrappers": "^0.8",
+        "lodash-es": "^4.17.21",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=18.0.0 || >=20.0.0 || >= 22.0.0"
+      }
+    },
+    "ui/node_modules/@holochain/client": {
+      "version": "0.20.4-rc.0",
+      "resolved": "https://registry.npmjs.org/@holochain/client/-/client-0.20.4-rc.0.tgz",
+      "integrity": "sha512-vE+RZKbn9t+3pRYQaxAiK0UFkHxDmYZgsD17XhlTkBhF3RvzjMFFgkKJzsx3Y5Jq+TiVXrm1+eGBm4F8KVzdGQ==",
+      "license": "CAL-1.0",
+      "dependencies": {
+        "@bitgo/blake2b": "^3.2.4",
+        "@msgpack/msgpack": "^3.1.2",
+        "emittery": "^1.2.0",
+        "isomorphic-ws": "^5.0.0",
+        "js-base64": "^3.7.8",
+        "js-sha512": "^0.9.0",
+        "libsodium-wrappers": "^0.8",
+        "lodash-es": "^4.17.21",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=18.0.0 || >=20.0.0 || >= 22.0.0"
+      }
+    },
     "ui/node_modules/@msgpack/msgpack": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.2.tgz",
@@ -9135,6 +9309,21 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true
+    },
+    "ui/node_modules/libsodium": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.8.2.tgz",
+      "integrity": "sha512-TsnGYMoZtpweT+kR+lOv5TVsnJ/9U0FZOsLFzFOMWmxqOAYXjX3fsrPAW+i1LthgDKXJnI9A8dWEanT1tnJKIw==",
+      "license": "ISC"
+    },
+    "ui/node_modules/libsodium-wrappers": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.8.2.tgz",
+      "integrity": "sha512-VFLmfxkxo+U9q60tjcnSomQBRx2UzlRjKWJqvB4K1pUqsMQg4cu3QXA2nrcsj9A1qRsnJBbi2Ozx1hsiDoCkhw==",
+      "license": "ISC",
+      "dependencies": {
+        "libsodium": "^0.8.0"
+      }
     },
     "ui/node_modules/svelte-gestures": {
       "version": "5.0.6",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "setup:happ-release": "curl -L https://github.com/HelloVolla/volla-messages/releases/download/happ-v0.11.0/relay.happ -o workdir/relay.happ"
   },
   "devDependencies": {
-    "@holochain/hc-spin": "^0.600.0",
+    "@holochain/hc-spin": "^0.600.2-rc.0",
     "@tauri-apps/cli": "^2.5.0",
     "@tsconfig/svelte": "^5.0.4",
     "@types/dompurify": "^3.0.5",

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,10 +16,10 @@
   },
   "dependencies": {
     "@buildyourwebapp/tauri-plugin-sharesheet": "0.0.1",
-    "@holochain-open-dev/elements": "^0.600.0",
+    "@holochain-open-dev/elements": "^0.601.0",
     "@holochain-open-dev/file-storage": "^0.600.0-dev.0",
-    "@holochain-open-dev/utils": "^0.600.0",
-    "@holochain/client": "^0.20.1",
+    "@holochain-open-dev/utils": "^0.601.0",
+    "@holochain/client": "0.20.4-rc.0",
     "@msgpack/msgpack": "^3.1.2",
     "@svelte-put/clickoutside": "^3.0.2",
     "@tanstack/svelte-virtual": "^3.13.0",

--- a/ui/src/lib/ContactListItem.svelte
+++ b/ui/src/lib/ContactListItem.svelte
@@ -37,7 +37,7 @@
     console.log("Running loadProfiles");
     if (!profiles) return;
 
-    await profiles.load(isFirstProfilesLoad);
+    await profiles.load(true); // allways load local because we don't want to trigger a network get that can take a long time.
     isFirstProfilesLoad = false;
     if (!hasAgentJoinedDht) {
       pollInterval = setTimeout(() => {

--- a/ui/src/routes/contacts/[id]/+page.svelte
+++ b/ui/src/routes/contacts/[id]/+page.svelte
@@ -59,7 +59,7 @@
   async function loadProfiles() {
     if (!profiles) return;
 
-    await profiles.load(isFirstProfilesLoad);
+    await profiles.load(true); // allways load local because we don't want to trigger a network get that can take a long time.
     isFirstProfilesLoad = false;
 
     if (!hasAgentJoinedDht) {

--- a/ui/src/routes/conversations/[id]/+page.svelte
+++ b/ui/src/routes/conversations/[id]/+page.svelte
@@ -95,7 +95,7 @@
    * Fetch agent profiles every 2s, until at least 2 profiles are received.
    */
   async function loadProfiles() {
-    await profiles.load(isFirstProfilesLoad);
+    await profiles.load(true); // allways load local because we don't want to trigger a network get that can take a long time.
     isFirstProfilesLoad = false;
     clearTimeout(agentTimeout);
 
@@ -117,7 +117,7 @@
    * navigating away from and back to this page.
    */
   async function loadConfig() {
-    await conversation.loadConfig(isFirstConfigLoad);
+    await conversation.loadConfig(true); // allways load local because we don't want to trigger a network get that can take a long time.
     isFirstConfigLoad = false;
     clearTimeout(configTimeout);
 
@@ -137,7 +137,7 @@
    */
   async function loadMessages() {
     clearTimeout(messageTimeout);
-    await loadMessagesInCurrentBucket(isFirstLoadMessages);
+    await loadMessagesInCurrentBucket(true); // allways load local because we don't want to trigger a network get that can take a long time.
     isFirstLoadMessages = false;
 
     if ($messages.count === 0) {
@@ -162,7 +162,7 @@
 
     loadingMessagesOld = true;
     try {
-      await messages.loadMessagesInPreviousBucketTargetCount(false); //TODO: is this ok to always be from network?
+      await messages.loadMessagesInPreviousBucketTargetCount(true); // allways load local because we don't want to trigger a network get that can take a long time.
     } catch (e) {
       console.error(e);
     }

--- a/ui/src/store/ConversationMessageStore.ts
+++ b/ui/src/store/ConversationMessageStore.ts
@@ -241,10 +241,11 @@ export function createConversationMessageStore(
         );
       }
 
-      // If no more messages in DB, try fetching from network
-      if (olderMessages.length === 0) {
-        loadedCount = await loadMessagesInPreviousBucketTargetCount(false, cellIdB64);
-      }
+      // This shouldn't be done, it will only likely trigger timeouts.  Unless the node is zero-arc (which we are not doing in Volla), all loading should be local.
+      // Data will be synced quickly and so it's not worth trying to get it from the network.
+      // if (olderMessages.length === 0) {
+      //   loadedCount = await loadMessagesInPreviousBucketTargetCount(false, cellIdB64);
+      // }
 
       return loadedCount;
     } catch (error) {


### PR DESCRIPTION
### Summary

- Updates need to the flake.lock and to hc-spin to be able to run volla-messages on holochain 0.6.1 when using `npm run spin`

- Makes all requests local (no Network gets)

