### PR TITLE
Volla Messages: Add Support for ARM based devices on Linux

### DIFF
--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -115,7 +115,9 @@ jobs:
                 libayatana-appindicator3-dev:armhf \
                 librsvg2-dev:armhf \
                 libxdo-dev:armhf \
-                libgtk-3-dev:armhf
+                libgtk-3-dev:armhf \
+                libgcc-11-dev:armhf \
+                libunwind-dev:armhf
           else
               # Standard dependencies for native builds
               sudo apt-get install -y \
@@ -170,6 +172,7 @@ jobs:
           echo "PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig:/usr/share/pkgconfig" >> $GITHUB_ENV
           echo "PKG_CONFIG_SYSROOT_DIR=/" >> $GITHUB_ENV
           echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS=-C link-arg=-lgcc_s -C link-arg=-lunwind" >> $GITHUB_ENV
 
       - id: build-app
         uses: tauri-apps/tauri-action@v0

--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -173,13 +173,8 @@ jobs:
           echo "PKG_CONFIG_SYSROOT_DIR=/" >> $GITHUB_ENV
           echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
 
-          # Create a wrapper script for the linker to ensure libgcc is linked
-          cat > /tmp/arm-linker-wrapper.sh << 'EOF'
-          #!/bin/bash
-          arm-linux-gnueabihf-gcc "$@" -lgcc_s -lunwind
-          EOF
-          chmod +x /tmp/arm-linker-wrapper.sh
-          echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=/tmp/arm-linker-wrapper.sh" >> $GITHUB_ENV
+          # Add library search paths and link libraries via RUSTFLAGS
+          echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS=-L/usr/lib/gcc-cross/arm-linux-gnueabihf/11 -C link-arg=-Wl,--start-group -C link-arg=-lgcc_eh -C link-arg=-lunwind -C link-arg=-Wl,--end-group" >> $GITHUB_ENV
 
       - id: build-app
         uses: tauri-apps/tauri-action@v0

--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -80,22 +80,45 @@ jobs:
         run: |
           sudo apt-get update
 
-          sudo apt-get install -y \
-            libsoup-3.0-dev \
-            libwebkit2gtk-4.1-dev \
-            build-essential \
-            curl \
-            wget \
-            file \
-            libxdo-dev \
-            libssl-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            pkg-config
-
-          # Install ARM cross-compilation toolchain for armv7
+          # Install ARM cross-compilation toolchain and libraries for armv7
           if [ "${{ matrix.arch }}" = "armv7" ]; then
-              sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+              # Add armhf architecture
+              sudo dpkg --add-architecture armhf
+              sudo apt-get update
+
+              # Install cross-compilation toolchain
+              sudo apt-get install -y \
+                gcc-arm-linux-gnueabihf \
+                g++-arm-linux-gnueabihf \
+                pkg-config \
+                build-essential \
+                curl \
+                wget \
+                file
+
+              # Install ARM libraries for cross-compilation
+              sudo apt-get install -y \
+                libwebkit2gtk-4.1-dev:armhf \
+                libsoup-3.0-dev:armhf \
+                libssl-dev:armhf \
+                libayatana-appindicator3-dev:armhf \
+                librsvg2-dev:armhf \
+                libxdo-dev:armhf \
+                libgtk-3-dev:armhf
+          else
+              # Standard dependencies for native builds
+              sudo apt-get install -y \
+                libsoup-3.0-dev \
+                libwebkit2gtk-4.1-dev \
+                build-essential \
+                curl \
+                wget \
+                file \
+                libxdo-dev \
+                libssl-dev \
+                libayatana-appindicator3-dev \
+                librsvg2-dev \
+                pkg-config
           fi
 
           # We must pin webkitgtk to 2.44 for x86_64, as we get a blank screen on later versions.
@@ -128,6 +151,14 @@ jobs:
       - name: Copy variant tauri config
         run: |
           cp -f src-tauri/tauri.desktop.conf.json src-tauri/tauri.conf.json
+
+      - name: Set up cross-compilation environment for armv7
+        if: matrix.arch == 'armv7'
+        run: |
+          echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
+          echo "PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig:/usr/share/pkgconfig" >> $GITHUB_ENV
+          echo "PKG_CONFIG_SYSROOT_DIR=/" >> $GITHUB_ENV
+          echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
 
       - id: build-app
         uses: tauri-apps/tauri-action@v0

--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -33,38 +33,56 @@ jobs:
     needs: create-release
     permissions: write-all
     environment: Relay Release
-    runs-on: [self-hosted, yolo]
-    container:
-      image: ubuntu:22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: [self-hosted, yolo]
+            target: x86_64-unknown-linux-gnu
+            container: ubuntu:22.04
+          - arch: aarch64
+            runner: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-gnu
+            container: null
+          - arch: armv7
+            runner: ubuntu-22.04
+            target: armv7-unknown-linux-gnueabihf
+            container: null
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install packages
+      - name: Install packages (container only)
+        if: matrix.container != null
         run: |
           apt-get update
           apt-get install -y sudo build-essential curl openjdk-11-jdk unzip git cmake clang libclang-dev
 
-      - name: setup node
-        uses: actions/setup-node@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
         with:
           node-version: 20
 
-      - name: install Rust stable
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
         with:
-          override: true
-          toolchain: 1.89
+          toolchain: "1.89"
+          targets: ${{ matrix.target }}
 
-      - name: install Go stable
+      - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: "stable"
+          go-version: stable
 
       - name: install dependencies (ubuntu only)
         run: |
           sudo apt-get update
-          
+
           sudo apt-get install -y \
+            libsoup-3.0-dev \
+            libwebkit2gtk-4.1-dev \
             build-essential \
             curl \
             wget \
@@ -72,29 +90,30 @@ jobs:
             libxdo-dev \
             libssl-dev \
             libayatana-appindicator3-dev \
-            librsvg2-dev
+            librsvg2-dev \
+            pkg-config
 
-          # We must pin webkitgtk to 2.46, as we get a blank screen on later versions.
+          # We must pin webkitgtk to 2.44 for x86_64, as we get a blank screen on later versions.
           # See https://github.com/tauri-apps/tauri/issues/12431
           #
-          # Because libwebkit2gtk-4.1-dev version 2.46 has been removed from the apt repositories,
-          # we must manually download the deb packages from launchpad to install it.
-
-          mkdir -p /tmp/ubuntu-packages
-          cd /tmp/ubuntu-packages
-          wget https://launchpadlibrarian.net/723972773/libwebkit2gtk-4.1-0_2.44.0-0ubuntu0.22.04.1_amd64.deb
-          wget https://launchpadlibrarian.net/723972761/libwebkit2gtk-4.1-dev_2.44.0-0ubuntu0.22.04.1_amd64.deb
-          wget https://launchpadlibrarian.net/723972770/libjavascriptcoregtk-4.1-0_2.44.0-0ubuntu0.22.04.1_amd64.deb
-          wget https://launchpadlibrarian.net/723972746/libjavascriptcoregtk-4.1-dev_2.44.0-0ubuntu0.22.04.1_amd64.deb
-          wget https://launchpadlibrarian.net/723972735/gir1.2-javascriptcoregtk-4.1_2.44.0-0ubuntu0.22.04.1_amd64.deb
-          wget https://launchpadlibrarian.net/723972739/gir1.2-webkit2-4.1_2.44.0-0ubuntu0.22.04.1_amd64.deb
-          wget https://launchpadlibrarian.net/606433947/libicu70_70.1-2ubuntu1_amd64.deb
-          wget https://launchpadlibrarian.net/606433941/libicu-dev_70.1-2ubuntu1_amd64.deb
-          wget https://launchpadlibrarian.net/606433945/icu-devtools_70.1-2ubuntu1_amd64.deb
-          wget https://launchpadlibrarian.net/595623693/libjpeg8_8c-2ubuntu10_amd64.deb
-          wget https://launchpadlibrarian.net/587202140/libjpeg-turbo8_2.1.2-0ubuntu1_amd64.deb
-          wget https://launchpadlibrarian.net/592959859/xdg-desktop-portal-gtk_1.14.0-1build1_amd64.deb
-          sudo apt-get install -y /tmp/ubuntu-packages/*.deb
+          # Only pin WebKitGTK on amd64 as these are arch-specific deb packages
+          if [ "${{ matrix.arch }}" = "x86_64" ]; then
+              mkdir -p /tmp/ubuntu-packages
+              cd /tmp/ubuntu-packages
+              wget https://launchpadlibrarian.net/723972773/libwebkit2gtk-4.1-0_2.44.0-0ubuntu0.22.04.1_amd64.deb
+              wget https://launchpadlibrarian.net/723972761/libwebkit2gtk-4.1-dev_2.44.0-0ubuntu0.22.04.1_amd64.deb
+              wget https://launchpadlibrarian.net/723972770/libjavascriptcoregtk-4.1-0_2.44.0-0ubuntu0.22.04.1_amd64.deb
+              wget https://launchpadlibrarian.net/723972746/libjavascriptcoregtk-4.1-dev_2.44.0-0ubuntu0.22.04.1_amd64.deb
+              wget https://launchpadlibrarian.net/723972735/gir1.2-javascriptcoregtk-4.1_2.44.0-0ubuntu0.22.04.1_amd64.deb
+              wget https://launchpadlibrarian.net/723972739/gir1.2-webkit2-4.1_2.44.0-0ubuntu0.22.04.1_amd64.deb
+              wget https://launchpadlibrarian.net/606433947/libicu70_70.1-2ubuntu1_amd64.deb
+              wget https://launchpadlibrarian.net/606433941/libicu-dev_70.1-2ubuntu1_amd64.deb
+              wget https://launchpadlibrarian.net/606433945/icu-devtools_70.1-2ubuntu1_amd64.deb
+              wget https://launchpadlibrarian.net/595623693/libjpeg8_8c-2ubuntu10_amd64.deb
+              wget https://launchpadlibrarian.net/587202140/libjpeg-turbo8_2.1.2-0ubuntu1_amd64.deb
+              wget https://launchpadlibrarian.net/592959859/xdg-desktop-portal-gtk_1.14.0-1build1_amd64.deb
+              sudo apt-get install -y /tmp/ubuntu-packages/*.deb
+          fi
 
       - name: Install and prepare
         run: |
@@ -111,7 +130,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           releaseId: ${{ needs.create-release.outputs.releaseId }}
-          args: --verbose --features holochain_bundled
+          args: --verbose --features holochain_bundled --target ${{ matrix.target }}
 
   release-tauri-app-android:
     permissions: write-all

--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -172,7 +172,14 @@ jobs:
           echo "PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig:/usr/share/pkgconfig" >> $GITHUB_ENV
           echo "PKG_CONFIG_SYSROOT_DIR=/" >> $GITHUB_ENV
           echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
-          echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS=-C link-arg=-lgcc_s -C link-arg=-lunwind" >> $GITHUB_ENV
+
+          # Create a wrapper script for the linker to ensure libgcc is linked
+          cat > /tmp/arm-linker-wrapper.sh << 'EOF'
+          #!/bin/bash
+          arm-linux-gnueabihf-gcc "$@" -lgcc_s -lunwind
+          EOF
+          chmod +x /tmp/arm-linker-wrapper.sh
+          echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=/tmp/arm-linker-wrapper.sh" >> $GITHUB_ENV
 
       - id: build-app
         uses: tauri-apps/tauri-action@v0

--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -85,6 +85,10 @@ jobs:
               # Add armhf architecture
               sudo dpkg --add-architecture armhf
 
+              # Restrict default sources.list to only amd64 architecture
+              sudo sed -i 's/^deb /deb [arch=amd64] /g' /etc/apt/sources.list
+              sudo sed -i 's/^deb-src /deb-src [arch=amd64] /g' /etc/apt/sources.list
+
               # Add ARM ports repository for armhf packages
               echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/armhf.list
               echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/armhf.list

--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -93,6 +93,11 @@ jobs:
             librsvg2-dev \
             pkg-config
 
+          # Install ARM cross-compilation toolchain for armv7
+          if [ "${{ matrix.arch }}" = "armv7" ]; then
+              sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+          fi
+
           # We must pin webkitgtk to 2.44 for x86_64, as we get a blank screen on later versions.
           # See https://github.com/tauri-apps/tauri/issues/12431
           #

--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -45,10 +45,6 @@ jobs:
             runner: ubuntu-22.04-arm
             target: aarch64-unknown-linux-gnu
             container: null
-          - arch: armv7
-            runner: ubuntu-22.04
-            target: armv7-unknown-linux-gnueabihf
-            container: null
     runs-on: ${{ matrix.runner }}
     container: ${{ matrix.container }}
     steps:

--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -84,6 +84,13 @@ jobs:
           if [ "${{ matrix.arch }}" = "armv7" ]; then
               # Add armhf architecture
               sudo dpkg --add-architecture armhf
+
+              # Add ARM ports repository for armhf packages
+              echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/armhf.list
+              echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/armhf.list
+              echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/armhf.list
+              echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports jammy-security main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list.d/armhf.list
+
               sudo apt-get update
 
               # Install cross-compilation toolchain


### PR DESCRIPTION
### Summary
 This PR adds build support for ARM-based devices enabling Volla Messages to run on modern ARM hardware
  including Raspberry Pi, Snapdragon-based laptops, and Apple Silicon devices with Linux based distros.

This extends Volla Messages Support to following devices

     - Raspberry Pi 3, 4, and 5
    - Modern ARM Linux laptops (Powered by Snapdragon X Elite, MTK Companio, etc.)
    - Macbook M-series devices running Asahi Linux
    - ARM-based servers and development boards

### TODO:
- ARM 64-bit is working fine
- ARM 32-bit (armhf/v7, used on raspberry pi and earlier ARM SoCs), the work is still pending

PS:   - ARM32 (armv7) Linux support was attempted but excluded due to incompatibility issues with the wasmer WebAssembly runtime used by Holochain.