### PR TITLE
volla-messages: Add support for Android ARM32 (v7) builds

### DIFF
--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -196,18 +196,18 @@ jobs:
       - name: Build android AAB
         run: |
           cargo clean
-          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri:android:build:${{ matrix.feature }} -- --aab --target aarch64 --target x86_64"
+          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri:android:build:${{ matrix.feature }} -- --aab --target aarch64 --target armv7 --target x86_64"
 
       - name: Build android APK (aarch64)
         run: |
           cargo clean
           nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri:android:build:${{ matrix.feature }} -- --apk --split-per-abi --target aarch64"
 
-      # - name: Build android APK (i684)
-      #   run: |
-      #     cargo clean
-      #     nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri:android:build:${{ matrix.feature }} -- --apk --split-per-abi --target i686"
-      
+      - name: Build android APK (armv7)
+        run: |
+          cargo clean
+          nix develop .#androidDev --no-update-lock-file --command bash -c "npm run tauri:android:build:${{ matrix.feature }} -- --apk --split-per-abi --target armv7"
+
       - name: Build android APK (x86_64)
         run: |
           cargo clean


### PR DESCRIPTION
### Summary
- Added support for Android armv7 build architecture.
- Makes volla messages app compatible with older Android mobile phones, and also with wearos watches and android TVs because they also use same arch.

