### PR TITLE
Feature/25 joining event notice

### DIFF
--- a/dnas/relay/zomes/integrity/relay/src/message.rs
+++ b/dnas/relay/zomes/integrity/relay/src/message.rs
@@ -1,5 +1,11 @@
 use hdi::prelude::*;
 
+#[derive(Serialize, Deserialize, Debug, Clone, SerializedBytes, PartialEq)]
+pub enum MessageType {
+    User,
+    System,
+}
+
 #[derive(Serialize, Deserialize, Debug, SerializedBytes, Clone, PartialEq)]
 pub struct File {
     pub name: String,
@@ -15,6 +21,7 @@ pub struct Message {
     pub content: String,
     pub bucket: u32,
     pub images: Vec<File>,
+    pub message_type: MessageType,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -81,10 +81,16 @@ export interface MessageFile {
  */
 
 // Mirror of rust struct "File", renamed to avoid naming conflict with javascript native File
+export enum MessageType {
+  User = "User",
+  System = "System",
+}
+
 export interface Message {
   content: string;
   bucket: number;
   images: MessageFile[];
+  message_type: MessageType;
 }
 
 export interface MessageExtended {

--- a/ui/src/routes/conversations/MessagePreview.svelte
+++ b/ui/src/routes/conversations/MessagePreview.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Avatar from "$lib/Avatar.svelte";
-  import type { CellIdB64, MessageExtended } from "$lib/types";
+  import { MessageType, type CellIdB64, type MessageExtended } from "$lib/types";
   import { t } from "$translations";
   import DOMPurify from "dompurify";
   import AgentNickname from "$lib/AgentNickname.svelte";
@@ -19,30 +19,37 @@
   $: hasFiles = otherFiles.length > 0;
 </script>
 
-<div class="mt-1 flex items-start justify-start space-x-2">
-  <div class=" flex items-start justify-start space-x-1">
-    <Avatar agentPubKeyB64={messageExtended.authorAgentPubKeyB64} {cellIdB64} size={14} />
+{#if messageExtended.message.message_type === MessageType.System}
+  <div class="text-secondary-400 mt-1 flex items-center space-x-1 italic">
     <AgentNickname {cellIdB64} agentPubKeyB64={messageExtended.authorAgentPubKeyB64} />
+    <span>{$t("common.joined_the_conversation")}</span>
   </div>
-
-  <div class="overflow-wrap-anywhere overflow-hidden whitespace-normal break-words">
-    {@html DOMPurify.sanitize(messageExtended.message.content)}
-  </div>
-
-  {#if hasImages || hasFiles}
-    <div class="text-secondary-400 italic">
-      ({#if hasImages}
-        {$t("common.images", {
-          count: imageFiles.length,
-        })}
-      {/if}
-      {#if hasImages && hasFiles},
-      {/if}
-      {#if hasFiles}
-        {$t("common.files", {
-          count: otherFiles.length,
-        })}
-      {/if})
+{:else}
+  <div class="mt-1 flex items-start justify-start space-x-2">
+    <div class=" flex items-start justify-start space-x-1">
+      <Avatar agentPubKeyB64={messageExtended.authorAgentPubKeyB64} {cellIdB64} size={14} />
+      <AgentNickname {cellIdB64} agentPubKeyB64={messageExtended.authorAgentPubKeyB64} />
     </div>
-  {/if}
-</div>
+
+    <div class="overflow-wrap-anywhere overflow-hidden whitespace-normal break-words">
+      {@html DOMPurify.sanitize(messageExtended.message.content)}
+    </div>
+
+    {#if hasImages || hasFiles}
+      <div class="text-secondary-400 italic">
+        ({#if hasImages}
+          {$t("common.images", {
+            count: imageFiles.length,
+          })}
+        {/if}
+        {#if hasImages && hasFiles},
+        {/if}
+        {#if hasFiles}
+          {$t("common.files", {
+            count: otherFiles.length,
+          })}
+        {/if})
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/ui/src/routes/conversations/[id]/ConversationMessages.svelte
+++ b/ui/src/routes/conversations/[id]/ConversationMessages.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { isMobile, isSameDay, isWithinFiveMinutes } from "$lib/utils";
   import type { ActionHashB64 } from "@holochain/client";
-  import type { MessageExtended, CellIdB64 } from "$lib/types";
+  import { MessageType, type MessageExtended, type CellIdB64 } from "$lib/types";
   import BaseMessage from "./Message.svelte";
+  import NoticeMessage from "./NoticeMessage.svelte";
   import ConversationHeader from "./ConversationHeader.svelte";
   import { createVirtualizer } from "@tanstack/svelte-virtual";
   import { afterUpdate, beforeUpdate, createEventDispatcher, onMount, tick } from "svelte";
@@ -216,6 +217,9 @@ afterUpdate(() => {
 
     if (!currentMsg || !prevMsg) return true;
 
+    // Always show author after a system notice
+    if (prevMsg.message.message_type === MessageType.System) return true;
+
     return (
       currentMsg.authorAgentPubKeyB64 !== prevMsg.authorAgentPubKeyB64 ||
       !isWithinFiveMinutes(
@@ -268,19 +272,23 @@ afterUpdate(() => {
           {/if}
 
           <!-- Message content -->
-          <div class="mt-3 px-4">
-            <BaseMessage
-              {cellIdB64}
-              message={messageExtended}
-              isSelected={selected === actionHashB64}
-              showAuthor={shouldShowAuthor(currentIndex)}
-              {actionHashB64}
-              on:press={() => handlePress(actionHashB64)}
-              on:click={(e) => handleClick(e, actionHashB64)}
-              on:clickoutside={handleClickOutside}
-              on:delete
-            />
-          </div>
+          {#if messageExtended.message.message_type === MessageType.System}
+            <NoticeMessage {cellIdB64} message={messageExtended} />
+          {:else}
+            <div class="mt-3 px-4">
+              <BaseMessage
+                {cellIdB64}
+                message={messageExtended}
+                isSelected={selected === actionHashB64}
+                showAuthor={shouldShowAuthor(currentIndex)}
+                {actionHashB64}
+                on:press={() => handlePress(actionHashB64)}
+                on:click={(e) => handleClick(e, actionHashB64)}
+                on:clickoutside={handleClickOutside}
+                on:delete
+              />
+            </div>
+          {/if}
 
           <!-- Padding at the very end of the chat -->
           {#if currentIndex === chronologicalMessages?.length - 1}

--- a/ui/src/routes/conversations/[id]/NoticeMessage.svelte
+++ b/ui/src/routes/conversations/[id]/NoticeMessage.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import type { CellIdB64, MessageExtended } from "$lib/types";
+  import AgentNickname from "$lib/AgentNickname.svelte";
+  import { t } from "$translations";
+
+  export let cellIdB64: CellIdB64;
+  export let message: MessageExtended;
+</script>
+
+<div class="text-secondary-400 dark:text-secondary-300 my-2 flex items-center justify-center gap-1 px-4 text-xs">
+  <AgentNickname {cellIdB64} agentPubKeyB64={message.authorAgentPubKeyB64} />
+  <span>{$t("common.joined_the_conversation")}</span>
+</div>

--- a/ui/src/routes/conversations/join/+page.svelte
+++ b/ui/src/routes/conversations/join/+page.svelte
@@ -6,12 +6,16 @@
   import Button from "$lib/Button.svelte";
   import Header from "$lib/Header.svelte";
   import { t } from "$translations";
-  import type { Invitation } from "$lib/types";
+  import { Privacy, type Invitation } from "$lib/types";
   import type { ConversationStore } from "$store/ConversationStore";
+  import type { ConversationMessageStore } from "$store/ConversationMessageStore";
 
   const conversationStore = getContext<{ getStore: () => ConversationStore }>(
     "conversationStore",
   ).getStore();
+  const conversationMessageStore = getContext<{
+    getStore: () => ConversationMessageStore;
+  }>("conversationMessageStore").getStore();
 
   let inviteCode = "";
   let joining = false;
@@ -23,6 +27,15 @@
       const msgpack = Base64.toUint8Array(inviteCode);
       const invitation: Invitation = decode(msgpack) as Invitation;
       const cellIdB64 = await conversationStore.join(invitation);
+
+      // Send a join notice message to public conversations only
+      if (invitation.privacy === Privacy.Public) {
+        try {
+          await conversationMessageStore.sendJoinNotice(cellIdB64);
+        } catch (e) {
+          console.error("Failed to send join notice:", e);
+        }
+      }
 
       goto(`/conversations/${cellIdB64}`);
     } catch (e) {
@@ -40,14 +53,14 @@
   <div class="mx-auto flex w-full grow flex-col items-start justify-center px-10">
     <h1 class="h1">{$t("common.enter_invite_code")}</h1>
     <input
-      class="bg-surface-900 mt-2 w-full overflow-hidden text-ellipsis border-none pl-0.5 outline-none focus:outline-none focus:ring-0"
+      class="mt-2 w-full overflow-hidden text-ellipsis border-none bg-surface-900 pl-0.5 outline-none focus:outline-none focus:ring-0"
       type="text"
       placeholder="e.g. hLBjb252ZXJzYXRpb25OYW1lq0..."
       name="inviteCode"
       bind:value={inviteCode}
     />
     {#if error}
-      <p class="text-error-500 mt-2 text-sm">
+      <p class="mt-2 text-sm text-error-500">
         {$t("common.error_joining")}
       </p>
     {/if}

--- a/ui/src/store/ConversationMessageStore.ts
+++ b/ui/src/store/ConversationMessageStore.ts
@@ -7,6 +7,7 @@ import {
   type MessageRecord,
   type MessageSignal,
   type ProfileExtended,
+  MessageType,
 } from "$lib/types";
 import { encodeCellIdToBase64, decodeCellIdFromBase64, enqueueNotification } from "$lib/utils";
 import { EntryRecord } from "@holochain-open-dev/utils";
@@ -61,6 +62,7 @@ export interface ConversationMessageStore extends GenericKeyKeyValueStore<Messag
   ) => Promise<number>;
   loadMoreMessages: (key1: CellIdB64) => Promise<number>;
   sendMessage: (key1: CellIdB64, content: string, files: LocalFile[]) => Promise<void>;
+  sendJoinNotice: (key1: CellIdB64) => Promise<void>;
   deleteMessage: (key1: CellIdB64, messageContent: string) => Promise<void>;
   handleMessageSignalReceived: (key1: CellIdB64, signal: MessageSignal) => Promise<void>;
   handleMessageDeletedSignalReceived: (
@@ -90,32 +92,34 @@ export function createConversationMessageStore(
       const filteredMessages = Object.fromEntries(
         $messages.list.map(([cellIdB64, messagesData]) => {
           const messagesArray = Object.entries(messagesData);
-          
+
           // Check if profiles have loaded for this cell
-          const profilesLoadedForCell = $mergedProfileContactInviteStore.data[cellIdB64] !== undefined;
-          
+          const profilesLoadedForCell =
+            $mergedProfileContactInviteStore.data[cellIdB64] !== undefined;
+
           // If profiles haven't loaded yet, show all messages (prevent race condition)
           // Once profiles load, filter to only show messages from known authors
-          const filtered = messagesArray.filter(
-            ([actionHash, messageExtended]) => {
-              // If profiles not loaded yet, don't filter anything out
-              if (!profilesLoadedForCell) {
-                return true;
-              }
-              
-              // Profiles are loaded, so only show messages from known authors
-              const hasAuthor = $mergedProfileContactInviteStore.data[cellIdB64][
+          const filtered = messagesArray.filter(([actionHash, messageExtended]) => {
+            // If profiles not loaded yet, don't filter anything out
+            if (!profilesLoadedForCell) {
+              return true;
+            }
+
+            // Always show system messages
+            if (messageExtended.message.message_type === MessageType.System) {
+              return true;
+            }
+
+            // Profiles are loaded, so only show messages from known authors
+            const hasAuthor =
+              $mergedProfileContactInviteStore.data[cellIdB64][
                 messageExtended.authorAgentPubKeyB64
               ] !== undefined;
-              
-              return hasAuthor;
-            },
-          );
-          
-          return [
-            cellIdB64,
-            Object.fromEntries(filtered),
-          ];
+
+            return hasAuthor;
+          });
+
+          return [cellIdB64, Object.fromEntries(filtered)];
         }),
       );
 
@@ -155,26 +159,32 @@ export function createConversationMessageStore(
     const results = await Promise.allSettled(
       cellInfos.map(async (cellInfo) => {
         const cellIdB64 = encodeCellIdToBase64(cellInfo.cell_id);
-        
+
         await _loadMessagesFromDB(cellIdB64, 1); // Load first page
 
         // If no messages in DB, try to fetch from network
         const currentState = get(paginationState)[cellIdB64];
-        
+
         if (currentState.totalMessages === 0) {
           // when first initializing go local
-          await loadMessagesInCurrentBucketTargetCount(true, cellIdB64, TARGET_MESSAGES_COUNT, 10, 50);
+          await loadMessagesInCurrentBucketTargetCount(
+            true,
+            cellIdB64,
+            TARGET_MESSAGES_COUNT,
+            10,
+            50,
+          );
         }
       }),
     );
-    
+
     // Log any errors
     results.forEach((result, index) => {
       if (result.status === "rejected") {
         console.error(`Failed to load messages for conversation ${index}:`, result.reason);
       }
     });
-    
+
     console.log(" Initialization complete");
   }
 
@@ -185,10 +195,10 @@ export function createConversationMessageStore(
   async function _loadMessagesFromDB(cellIdB64: CellIdB64, pagesToLoad: number): Promise<void> {
     try {
       const limit = pagesToLoad * MESSAGES_PER_PAGE;
-      
+
       // Check if agent changed and clear cache if needed
       const cacheCleared = await messageDB.clearCacheOnAgentChange(cellIdB64);
-      
+
       const dbMessages = await messageDB.getMessages(cellIdB64, limit);
       console.log(` Retrieved ${dbMessages.length} messages from IndexedDB`);
 
@@ -206,7 +216,7 @@ export function createConversationMessageStore(
         messages.update((m) => {
           const existing = m[cellIdB64] || {};
           const merged = { ...existing, ...messageData };
-          
+
           return {
             ...m,
             [cellIdB64]: merged,
@@ -222,7 +232,6 @@ export function createConversationMessageStore(
             oldestLoadedTimestamp: messagesToKeep[messagesToKeep.length - 1]?.[1].timestamp, // Last (oldest) message in memory
           },
         }));
-
       } else {
         console.warn(`No messages found in IndexedDB for cell ${cellIdB64.substring(0, 10)}...`);
       }
@@ -278,42 +287,50 @@ export function createConversationMessageStore(
             ...state[cellIdB64],
             loadedPages: newLoadedPages,
             totalMessages: messagesToKeep.length,
-            oldestLoadedTimestamp: messagesToKeep[messagesToKeep.length - 1]?.[1].timestamp, 
+            oldestLoadedTimestamp: messagesToKeep[messagesToKeep.length - 1]?.[1].timestamp,
           },
         }));
       }
 
       // This shouldn't be done, it will only likely trigger timeouts.  Unless the node is zero-arc (which we are not doing in Volla), all loading should be local.
       // Data will be synced quickly and so it's not worth trying to get it from the network.
-    if (olderMessages.length === 0) {
+      if (olderMessages.length === 0) {
         console.log(`Local DB empty. Using reliable backend sync...`);
-        
+
         try {
           const cellId = decodeCellIdFromBase64(cellIdB64);
-          
+
           // 1. Get the actual oldest message from memory to find its exact bucket
           const currentMessages = get(messages).data[cellIdB64] || {};
-          const messagesList = Object.entries(currentMessages).sort(([, a], [, b]) => a.timestamp - b.timestamp);
+          const messagesList = Object.entries(currentMessages).sort(
+            ([, a], [, b]) => a.timestamp - b.timestamp,
+          );
           const oldestMessage = messagesList[0]?.[1];
-          
+
           if (!oldestMessage) return 0;
 
           // 2. Read the bucket directly from the message object (No timestamp math!)
           const oldestBucket = oldestMessage.message.bucket;
-          
+
           // 3. Safely ask for just the next 3 older buckets
-          const targetBuckets = [oldestBucket - 1, oldestBucket - 2, oldestBucket - 3].filter(b => b >= 0);
+          const targetBuckets = [oldestBucket - 1, oldestBucket - 2, oldestBucket - 3].filter(
+            (b) => b >= 0,
+          );
 
           if (targetBuckets.length > 0) {
             console.log(`Fetching buckets directly from DHT:`, targetBuckets);
-            
+
             const messageRecords = await client.getMessagesForBuckets(cellId, targetBuckets);
 
             if (messageRecords.length > 0) {
               const messageEntries = await Promise.allSettled(
-                messageRecords.map(async (m) =>
-                  [encodeHashToBase64(m.original_action), await _makeMessageExtended(cellId, m)] as [ActionHashB64, MessageExtended]
-                )
+                messageRecords.map(
+                  async (m) =>
+                    [
+                      encodeHashToBase64(m.original_action),
+                      await _makeMessageExtended(cellId, m),
+                    ] as [ActionHashB64, MessageExtended],
+                ),
               );
 
               const validMessages = messageEntries
@@ -374,6 +391,7 @@ export function createConversationMessageStore(
         content,
         bucket: conversationStore.getBucket(key1, new Date().getTime()),
         images: messageFiles,
+        message_type: MessageType.User,
       },
       agents: agentPubKeys,
     });
@@ -436,6 +454,53 @@ export function createConversationMessageStore(
         },
       };
     });
+  }
+
+  async function sendJoinNotice(key1: CellIdB64): Promise<void> {
+    const cellId = decodeCellIdFromBase64(key1);
+
+    // We just joined, so the local cache won't have other agents yet.
+    // If this fails, fall back to self, the message still lands on the DHT
+    // and others will see it when they next load messages.
+    let agentPubKeys;
+    try {
+      agentPubKeys = await client.getAgentsWithProfile(cellId);
+    } catch {
+      agentPubKeys = [client.client.myPubKey];
+    }
+
+    const message: Message = {
+      content: "",
+      bucket: conversationStore.getBucket(key1, new Date().getTime()),
+      images: [],
+      message_type: MessageType.System,
+    };
+
+    const record = await client.createMessage(cellId, {
+      message,
+      agents: agentPubKeys,
+    });
+
+    const entryMessage = new EntryRecord<Message>(record).entry;
+    if (entryMessage === undefined) throw new Error("Failed to decode Message entry from record");
+
+    const messageExtended = await _makeMessageExtended(cellId, {
+      message: entryMessage,
+      original_action: record.signed_action.hashed.hash,
+      signed_action: record.signed_action,
+    });
+
+    const actionHashB64 = encodeHashToBase64(record.signed_action.hashed.hash);
+
+    await messageDB.storeMessage(key1, actionHashB64, messageExtended);
+
+    messages.update((m) => ({
+      ...m,
+      [key1]: {
+        ...(m[key1] || {}),
+        [actionHashB64]: messageExtended,
+      },
+    }));
   }
 
   async function deleteMessage(key1: CellIdB64, actionHashB64: ActionHashB64): Promise<void> {
@@ -829,6 +894,8 @@ export function createConversationMessageStore(
     messageExtended: MessageExtended,
     fromProfile?: ProfileExtended,
   ) {
+    if (messageExtended.message.message_type === MessageType.System) return;
+
     const content =
       messageExtended.message.content.length > 125
         ? messageExtended.message.content.slice(0, 50) + "..."
@@ -900,6 +967,7 @@ export function createConversationMessageStore(
     loadMessagesInPreviousBucketTargetCount,
     loadMoreMessages,
     sendMessage,
+    sendJoinNotice,
     handleMessageSignalReceived,
     subscribe,
     deleteMessage,
@@ -925,6 +993,7 @@ export interface CellConversationMessageStore
   ) => Promise<number>;
   loadMoreMessages: () => Promise<number>;
   sendMessage: (content: string, files: LocalFile[]) => Promise<void>;
+  sendJoinNotice: () => Promise<void>;
   handleMessageSignalReceived: (signal: MessageSignal) => Promise<void>;
   debugGetAllMessages: () => Promise<Record[]>;
 }
@@ -966,6 +1035,7 @@ export function deriveCellConversationMessageStore(
     loadMoreMessages: () => conversationMessageStore.loadMoreMessages(key),
     sendMessage: (content: string, files: LocalFile[]) =>
       conversationMessageStore.sendMessage(key, content, files),
+    sendJoinNotice: () => conversationMessageStore.sendJoinNotice(key),
     handleMessageSignalReceived: (signal: MessageSignal) =>
       conversationMessageStore.handleMessageSignalReceived(key, signal),
     deleteMessage: (key1: CellIdB64, actionHashB64: ActionHashB64) =>

--- a/ui/src/translations/locales/bg.json
+++ b/ui/src/translations/locales/bg.json
@@ -31,6 +31,7 @@
   "files": "{{count}} {{count; 1:файл; default:файлове;}}",
   "invalid_contact_code": "Невалиден код за контакт",
   "join_conversation": "Участвайте в разговора",
+  "joined_the_conversation": "се присъедини към разговора",
   "jump_in": "Jump In",
   "last": "Last",
   "last_name": "Фамилно име",

--- a/ui/src/translations/locales/da.json
+++ b/ui/src/translations/locales/da.json
@@ -34,6 +34,7 @@
   "files": "{{count}} {{count; 1:fil; default:filer;}}",
   "invalid_contact_code": "Ugyldig kode",
   "join_conversation": "Deltag i konversation",
+  "joined_the_conversation": "har tilsluttet sig samtalen",
   "jump_in": "Hop ind",
   "last": "Efternavn",
   "last_name": "Indtast efternavn",

--- a/ui/src/translations/locales/de.json
+++ b/ui/src/translations/locales/de.json
@@ -57,6 +57,7 @@
   "files": "{{count}} {{count; 1:Datei; default:Dateien;}}",
   "invalid_contact_code": "Ungültiger Kontakt-Code",
   "join_conversation": "An der Konversation teilnehmen",
+  "joined_the_conversation": "ist der Unterhaltung beigetreten",
   "jump_in": "Hineinspringen",
   "large_file_error": "Anhänge dürfen maximal {{maxSize}} groß sein",
   "last": "Letzter",

--- a/ui/src/translations/locales/en.json
+++ b/ui/src/translations/locales/en.json
@@ -57,6 +57,7 @@
   "files": "{{count}} {{count; 1:file; default:files;}}",
   "invalid_contact_code": "Invalid contact code",
   "join_conversation": "Join Conversation",
+  "joined_the_conversation": "joined the conversation",
   "jump_in": "Jump In",
   "large_file_error": "Attached files are limited to {{maxSize}}",
   "last": "Last",

--- a/ui/src/translations/locales/es.json
+++ b/ui/src/translations/locales/es.json
@@ -31,6 +31,7 @@
   "files": "{{count}} {{count; 1:archivo; default:archivos;}}",
   "invalid_contact_code": "Código de contacto no válido",
   "join_conversation": "Participe en la conversación",
+  "joined_the_conversation": "se unió a la conversación",
   "jump_in": "Jump In",
   "last": "Last",
   "last_name": "Apellidos",

--- a/ui/src/translations/locales/fr.json
+++ b/ui/src/translations/locales/fr.json
@@ -31,6 +31,7 @@
   "files": "{{count}} {{count; 1:fichier; default:fichiers;}}",
   "invalid_contact_code": "Code de contact non valide",
   "join_conversation": "Participer à la conversation",
+  "joined_the_conversation": "a rejoint la conversation",
   "jump_in": "Jump In",
   "last": "Last",
   "last_name": "Nom de famille",

--- a/ui/src/translations/locales/it.json
+++ b/ui/src/translations/locales/it.json
@@ -31,6 +31,7 @@
   "files": "{{count}} {{count; 1:file; default:file;}}",
   "invalid_contact_code": "Codice di contatto non valido",
   "join_conversation": "Partecipare alla conversazione",
+  "joined_the_conversation": "si è unito alla conversazione",
   "jump_in": "Jump In",
   "last": "Last",
   "last_name": "Cognome",

--- a/ui/src/translations/locales/nl.json
+++ b/ui/src/translations/locales/nl.json
@@ -35,6 +35,7 @@
   "files": "{{count}} {{count; 1:bestand; default:bestanden;}}",
   "invalid_contact_code": "Ongeldige contactcode",
   "join_conversation": "Neem deel aan het gesprek",
+  "joined_the_conversation": "is lid geworden van het gesprek",
   "jump_in": "Stap in",
   "last": "Laatste",
   "last_name": "Achternaam",

--- a/ui/src/translations/locales/no.json
+++ b/ui/src/translations/locales/no.json
@@ -34,6 +34,7 @@
   "files": "{{count}} {{count; 1:fil; default:filer;}}",
   "invalid_contact_code": "Ugyldig kode",
   "join_conversation": "Delta i konversasjon",
+  "joined_the_conversation": "ble med i samtalen",
   "jump_in": "Hopp inn",
   "last": "Etternavn",
   "last_name": "Skriv etternavn",

--- a/ui/src/translations/locales/ro.json
+++ b/ui/src/translations/locales/ro.json
@@ -31,6 +31,7 @@
   "files": "{{count}} {{count; 1:fișier; default:fișiere;}}",
   "invalid_contact_code": "Cod de contact invalid",
   "join_conversation": "Participați la conversație",
+  "joined_the_conversation": "s-a alăturat conversației",
   "jump_in": "Jump In",
   "last": "Încărcare",
   "last_name": "Numele de familie",

--- a/ui/src/translations/locales/sk.json
+++ b/ui/src/translations/locales/sk.json
@@ -31,6 +31,7 @@
   "files": "{{count}} {{count; 1:súbor; default:súbory;}}",
   "invalid_contact_code": "Neplatný kód kontaktu",
   "join_conversation": "Zapojte sa do konverzácie",
+  "joined_the_conversation": "sa pripojil ku konverzácii",
   "jump_in": "Jump In",
   "last": "Last",
   "last_name": "Priezvisko",

--- a/ui/src/translations/locales/sv.json
+++ b/ui/src/translations/locales/sv.json
@@ -34,6 +34,7 @@
   "files": "{{count}} {{count; 1:fil; default:filer;}}",
   "invalid_contact_code": "Ogiltig kod",
   "join_conversation": "Gå med i konversationen",
+  "joined_the_conversation": "gick med i konversationen",
   "jump_in": "Hoppa in",
   "last": "Efternamn",
   "last_name": "Efternamn, tack",


### PR DESCRIPTION
### Summary
Closes #35 

When a user joins a public conversation, their client creates a System-type message on the DHT. This message is signaled to existing members via send_remote_signal and rendered as a centered italic notice, "[Name] joined the conversation", in both the chat view and conversation list. Private conversations are unaffected.

**Approach:**
  - Added MessageType enum (User/System) to the existing Message entry, avoids a DNA-breaking change from introducing a new entry type
  - The joiner self-announces, gated on Privacy.Public
  - System messages bypass author-profile filtering, skip push notifications, and render via a dedicated NoticeMessage component with no action buttons (not deletable)

### TODO:
- [ ] CHANGELOG updated