### PR TITLE
Fix: Dexie upgrade fails when message-store primary key changed

### DIFF
--- a/ui/src/store/db/MessageDatabase.ts
+++ b/ui/src/store/db/MessageDatabase.ts
@@ -25,7 +25,16 @@ export class MessageDatabase extends Dexie {
   constructor() {
     super("VollaMessagesDB");
 
-    this.version(2).stores({
+    // v1 used `++id` as the primary key. IndexedDB does not allow changing
+    // a store's keyPath in place, so switching to `actionHashB64` as the PK
+    // requires dropping and recreating the store. Cached messages are
+    // re-fetchable from the DHT, so the data loss on upgrade is acceptable.
+    this.version(1).stores({
+      messages:
+        "++id, actionHashB64, cellIdB64, timestamp, bucket, [cellIdB64+timestamp], [cellIdB64+bucket]",
+    });
+    this.version(2).stores({ messages: null });
+    this.version(3).stores({
       messages:
         "actionHashB64, cellIdB64, timestamp, bucket, [cellIdB64+timestamp], [cellIdB64+bucket]",
     });


### PR DESCRIPTION
## Summary
- v2 of `VollaMessagesDB` silently changed the primary key from `++id` to `actionHashB64`, which IndexedDB does not support in place.
- Users with an existing v1 DB hit `UpgradeError: Not yet support for changing primary key` on launch, the DB gets closed, and every subsequent call (e.g. sending a message) surfaces as `DatabaseClosedError`.
- Fix by chaining v1 (re-declared) → v2 (drop store) → v3 (recreate with new PK). Dexie handles this as a legitimate schema change. Cached messages are dropped once per user on upgrade and repopulate from the DHT.

## Test plan
- [ ] On a device/profile with an existing v1 `VollaMessagesDB`, launch the app — no `UpgradeError` in the console, message sending works.
- [ ] On a fresh install, the DB is created at v3 directly and message storage/retrieval behaves as before.
- [ ] Verify bundled (`tauri_localhost_0`) and dev (`http_localhost_1420`) webview origins both migrate cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)