### PR TITLE
Feature/69 peer connectivity indicator

### DIFF
--- a/dnas/relay/zomes/coordinator/relay/src/lib.rs
+++ b/dnas/relay/zomes/coordinator/relay/src/lib.rs
@@ -6,36 +6,52 @@ pub mod ping;
 use hdk::prelude::*;
 use relay_integrity::*;
 
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "signal_type")]
+pub enum RemoteSignalPayload {
+    Message(MessageRecord),
+    PeerPing { from_agent: AgentPubKey },
+    PeerPong { from_agent: AgentPubKey },
+}
+
 #[hdk_extern]
-fn recv_remote_signal(message_record: MessageRecord) -> ExternResult<()> {
-    let info: CallInfo = call_info()?;
+fn recv_remote_signal(payload: RemoteSignalPayload) -> ExternResult<()> {
+    match payload {
+        RemoteSignalPayload::Message(message_record) => {
+            let info: CallInfo = call_info()?;
 
-    let is_deletion = match message_record.signed_action.action() {
-        Action::Delete(_) => true,
-        _ => false,
-    };
+            let is_deletion = match message_record.signed_action.action() {
+                Action::Delete(_) => true,
+                _ => false,
+            };
 
-    if is_deletion {
-        let signal = Signal::MessageDeleted {
-            action: message_record.signed_action.clone(),
-            original_action: message_record.original_action.clone(),
-            from: info.provenance,
-        };
-
-        debug!("recv_remote_signal: signal: {:?}", signal);
-
-        emit_signal(signal)
-    } else if let Some(message) = message_record.message {
-        let signal = Signal::Message {
-            action: message_record.signed_action.clone(),
-            message,
-            from: info.provenance,
-        };
-        emit_signal(signal)
-    } else {
-        Err(wasm_error!(WasmErrorInner::Guest(
-            "Invalid message record".to_string()
-        )))
+            if is_deletion {
+                let signal = Signal::MessageDeleted {
+                    action: message_record.signed_action.clone(),
+                    original_action: message_record.original_action.clone(),
+                    from: info.provenance,
+                };
+                debug!("recv_remote_signal: signal: {:?}", signal);
+                emit_signal(signal)
+            } else if let Some(message) = message_record.message {
+                let signal = Signal::Message {
+                    action: message_record.signed_action.clone(),
+                    message,
+                    from: info.provenance,
+                };
+                emit_signal(signal)
+            } else {
+                Err(wasm_error!(WasmErrorInner::Guest(
+                    "Invalid message record".to_string()
+                )))
+            }
+        }
+        RemoteSignalPayload::PeerPing { from_agent } => {
+            ping::handle_peer_ping(from_agent)
+        }
+        RemoteSignalPayload::PeerPong { from_agent } => {
+            ping::handle_peer_pong(from_agent)
+        }
     }
 }
 
@@ -64,6 +80,12 @@ pub enum Signal {
         action: SignedActionHashed,
         original_action: ActionHash,
         from: AgentPubKey,
+    },
+    PeerPing {
+        from_agent: AgentPubKey,
+    },
+    PeerPong {
+        from_agent: AgentPubKey,
     },
     LinkCreated {
         action: SignedActionHashed,

--- a/dnas/relay/zomes/coordinator/relay/src/message.rs
+++ b/dnas/relay/zomes/coordinator/relay/src/message.rs
@@ -35,11 +35,11 @@ pub fn create_message(input: SendMessageInput) -> ExternResult<Record> {
         .filter(|a| a != &my_pub_key)
         .collect();
     let _ = send_remote_signal(
-        MessageRecord {
+        crate::RemoteSignalPayload::Message(MessageRecord {
             message: Some(input.message),
             original_action: message_hash.clone(),
             signed_action: record.signed_action().clone(),
-        },
+        }),
         agents,
     );
 
@@ -98,11 +98,6 @@ pub fn get_message_links_for_buckets(buckets: Vec<u32>) -> ExternResult<Vec<Link
         links.append(&mut l);
     }
     Ok(links)
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct GetAgenProfileInput {
-    agent_key: AgentPubKey,
 }
 
 #[hdk_extern]
@@ -306,11 +301,11 @@ pub fn delete_message(input: DeleteMessageInput) -> ExternResult<ActionHash> {
         .filter(|a| a != &my_pub_key)
         .collect();
     let _ = send_remote_signal(
-        MessageRecord {
+        crate::RemoteSignalPayload::Message(MessageRecord {
             message: None,
             original_action: input.original_message_hash,
             signed_action: delete_record.signed_action().clone(),
-        },
+        }),
         agents,
     );
 

--- a/dnas/relay/zomes/coordinator/relay/src/ping.rs
+++ b/dnas/relay/zomes/coordinator/relay/src/ping.rs
@@ -2,5 +2,26 @@ use hdk::prelude::*;
 
 #[hdk_extern]
 pub fn ping(_: ()) -> ExternResult<()> {
-  Ok(())
+    Ok(())
+}
+
+#[hdk_extern]
+pub fn ping_agents(agents: Vec<AgentPubKey>) -> ExternResult<()> {
+    let me = agent_info()?.agent_initial_pubkey;
+    let signal = crate::RemoteSignalPayload::PeerPing { from_agent: me };
+    send_remote_signal(signal, agents)?;
+    Ok(())
+}
+
+pub fn handle_peer_ping(from_agent: AgentPubKey) -> ExternResult<()> {
+    let me = agent_info()?.agent_initial_pubkey;
+    let pong = crate::RemoteSignalPayload::PeerPong { from_agent: me };
+    send_remote_signal(pong, vec![from_agent.clone()])?;
+    emit_signal(crate::Signal::PeerPing { from_agent })?;
+    Ok(())
+}
+
+pub fn handle_peer_pong(from_agent: AgentPubKey) -> ExternResult<()> {
+    emit_signal(crate::Signal::PeerPong { from_agent })?;
+    Ok(())
 }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -34,9 +34,21 @@ export interface MessageDeleted {
   from: AgentPubKey;
 }
 
+export interface PeerPingSignal {
+  type: "PeerPing";
+  from_agent: AgentPubKey;
+}
+
+export interface PeerPongSignal {
+  type: "PeerPong";
+  from_agent: AgentPubKey;
+}
+
 export type RelaySignal =
   | MessageSignal
   | MessageDeleted
+  | PeerPingSignal
+  | PeerPongSignal
   | {
       type: "EntryCreated";
       action: SignedActionHashed<Create>;

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { AgentPubKeyB64, AppClient, CellId } from "@holochain/client";
   import { AppWebsocket, CellType, encodeHashToBase64 } from "@holochain/client";
+  import { writable, type Writable } from "svelte/store";
   import { onMount, setContext } from "svelte";
   import { t } from "$translations";
   import { createSignalHandler } from "$store/SignalHandler";
@@ -73,6 +74,8 @@
   let mergedProfileContactInviteUnjoinedStore: MergedProfileContactInviteUnjoinedStore;
   let mergedProfileContactInviteJoinedStore: MergedProfileContactInviteJoinedStore;
   let networkStatsStore: NetworkStatsStore;
+  let relayClient: RelayClient;
+  let onlinePeers: Writable<Set<AgentPubKeyB64>> = writable(new Set());
 
   // Is the holochain client connected?
   let isClientConnected = false;
@@ -146,7 +149,7 @@
   async function initStores() {
     try {
       // Setup stores
-      const relayClient = new RelayClient(client, provisionedRelayCellId);
+      relayClient = new RelayClient(client, provisionedRelayCellId);
       myPubKeyB64 = encodeHashToBase64(client.myPubKey);
       contactStore = createContactStore(relayClient);
       profileStore = createProfileStore(relayClient);
@@ -199,7 +202,7 @@
       await conversationMessageStore.initialize();
 
       // Initialize signal handler
-      createSignalHandler(relayClient, conversationStore, conversationMessageStore);
+      createSignalHandler(relayClient, conversationStore, conversationMessageStore, onlinePeers);
 
       isStoresSetup = true;
     } catch (e) {
@@ -273,6 +276,14 @@
 
   setContext("networkStatsStore", {
     getStore: () => networkStatsStore,
+  });
+
+  setContext("onlinePeers", {
+    getStore: () => onlinePeers,
+  });
+
+  setContext("relayClient", {
+    getClient: () => relayClient,
   });
 </script>
 

--- a/ui/src/routes/conversations/[id]/details/+page.svelte
+++ b/ui/src/routes/conversations/[id]/details/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { getContext } from "svelte";
-  import { type AgentPubKeyB64 } from "@holochain/client";
+  import { getContext, onDestroy, onMount } from "svelte";
+  import { type AgentPubKeyB64, decodeHashFromBase64 } from "@holochain/client";
   import { page } from "$app/stores";
   import Header from "$lib/Header.svelte";
   import SvgIcon from "$lib/SvgIcon.svelte";
@@ -29,9 +29,15 @@
     type MergedProfileContactInviteJoinedStore,
     type MergedProfileContactInviteUnjoinedStore,
   } from "$store/MergedProfileContactInviteJoinedStore";
+  import type { RelayClient } from "$store/RelayClient";
+  import type { Writable } from "svelte/store";
 
   const conversationStore = getContext<{ getStore: () => ConversationStore }>(
     "conversationStore",
+  ).getStore();
+  const relayClient = getContext<{ getClient: () => RelayClient }>("relayClient").getClient();
+  const onlinePeers = getContext<{ getStore: () => Writable<Set<AgentPubKeyB64>> }>(
+    "onlinePeers",
   ).getStore();
   const mergedProfileContactInviteStore = getContext<{
     getStore: () => MergedProfileContactInviteStore;
@@ -80,6 +86,29 @@
   let editingTitle = false;
 
   $: iAmProgenitor = myPubKeyB64 === $conversation.dnaProperties.progenitor;
+
+  let pingInterval: ReturnType<typeof setInterval>;
+
+  const pingParticipants = () => {
+    onlinePeers.set(new Set());
+    const agents = $joined.list
+      .map(([key]) => key)
+      .filter((key) => key !== myPubKeyB64)
+      .map((key) => decodeHashFromBase64(key));
+    if (agents.length === 0) return;
+    relayClient
+      .pingAgents($conversation.cellInfo.cell_id, agents)
+      .catch((e) => console.warn("Ping failed:", e));
+  };
+
+  onMount(() => {
+    pingParticipants();
+    pingInterval = setInterval(pingParticipants, 10_000);
+  });
+
+  onDestroy(() => {
+    clearInterval(pingInterval);
+  });
 
   const saveTitle = async (newTitle: string) => {
     conversation.updateConfig({ title: newTitle.trim(), image });
@@ -155,11 +184,13 @@
       {#if $conversation.dnaProperties.privacy === Privacy.Public && $conversation.publicInviteCode !== undefined}
         <li class="variant-filled-primary mb-2 flex flex-row items-center rounded-full p-2 text-xl">
           <span
-            class="bg-tertiary-500 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full"
+            class="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-tertiary-500"
           >
             <SvgIcon icon="addPerson" moreClasses="text-primary-600" />
           </span>
-          <span class="ml-2 min-w-0 flex-1 truncate text-sm font-bold sm:ml-4">{$t("common.add_members")}</span>
+          <span class="ml-2 min-w-0 flex-1 truncate text-sm font-bold sm:ml-4"
+            >{$t("common.add_members")}</span
+          >
 
           <ButtonsCopyShareInline
             text={$conversation.publicInviteCode}
@@ -169,7 +200,7 @@
         </li>
       {:else}
         {#if $unjoined.count > 0}
-          <h3 class="text-md text-secondary-300 mb-2 font-light">
+          <h3 class="text-md mb-2 font-light text-secondary-300">
             {$t("common.unconfirmed_invitations")}
           </h3>
 
@@ -186,7 +217,7 @@
           {/each}
         {/if}
 
-        <h3 class="text-md text-secondary-300 mb-2 mt-4 font-light">
+        <h3 class="text-md mb-2 mt-4 font-light text-secondary-300">
           {$t("common.members")}
         </h3>
       {/if}

--- a/ui/src/routes/conversations/[id]/details/MemberListItem.svelte
+++ b/ui/src/routes/conversations/[id]/details/MemberListItem.svelte
@@ -6,9 +6,13 @@
   import type { AgentPubKeyB64 } from "@holochain/client";
   import { getContext } from "svelte";
   import AgentNickname from "$lib/AgentNickname.svelte";
+  import type { Writable } from "svelte/store";
 
   const conversationStore = getContext<{ getStore: () => ConversationStore }>(
     "conversationStore",
+  ).getStore();
+  const onlinePeers = getContext<{ getStore: () => Writable<Set<AgentPubKeyB64>> }>(
+    "onlinePeers",
   ).getStore();
 
   export let cellIdB64: CellIdB64;
@@ -17,11 +21,18 @@
   let conversation = deriveCellConversationStore(conversationStore, cellIdB64);
 
   $: isAdmin = agentPubKeyB64 === $conversation.dnaProperties.progenitor;
+  $: isOnline = $onlinePeers.has(agentPubKeyB64);
 </script>
 
 <li class="mb-4 flex flex-row items-center px-2 text-xl">
-  <div class="shrink-0">
+  <div class="relative shrink-0">
     <Avatar {cellIdB64} {agentPubKeyB64} size={38} />
+    {#if isOnline}
+      <span
+        class="absolute -bottom-1 -right-1 block h-4 w-4 rounded-full border-2 border-white bg-green-500 dark:border-neutral-900"
+        title="Online"
+      ></span>
+    {/if}
   </div>
 
   <span class="ml-2 min-w-0 flex-1 truncate text-sm font-bold sm:ml-4">

--- a/ui/src/store/RelayClient.ts
+++ b/ui/src/store/RelayClient.ts
@@ -386,4 +386,13 @@ export class RelayClient {
       payload,
     });
   }
+
+  public async pingAgents(cellId: CellId, agents: AgentPubKey[]): Promise<void> {
+    return this.client.callZome({
+      cell_id: cellId,
+      zome_name: ZOME_NAME,
+      fn_name: "ping_agents",
+      payload: agents,
+    });
+  }
 }

--- a/ui/src/store/SignalHandler.ts
+++ b/ui/src/store/SignalHandler.ts
@@ -1,16 +1,17 @@
-import { encodeHashToBase64, type Signal, SignalType } from "@holochain/client";
+import { encodeHashToBase64, type Signal, SignalType, type AgentPubKeyB64 } from "@holochain/client";
 import { RelayClient } from "$store/RelayClient";
 import { type RelaySignal, type MessageSignal } from "$lib/types";
 import { encodeCellIdToBase64 } from "$lib/utils";
 import { type ConversationStore } from "./ConversationStore";
 import type { ConversationMessageStore } from "./ConversationMessageStore";
 import { page } from "$app/stores";
-import { get } from "svelte/store";
+import { get, type Writable } from "svelte/store";
 
 export function createSignalHandler(
   client: RelayClient,
   conversationStore: ConversationStore,
   conversationMessageStore: ConversationMessageStore,
+  onlinePeers: Writable<Set<AgentPubKeyB64>>,
 ) {
   client.client.on("signal", _handleSignalReceived);
 
@@ -20,13 +21,17 @@ export function createSignalHandler(
     const payload = signal.value.payload as RelaySignal;
     const cellIdB64 = encodeCellIdToBase64(signal.value.cell_id);
 
+    if (payload.type === "PeerPing" || payload.type === "PeerPong") {
+      const fromAgent = encodeHashToBase64(payload.from_agent);
+      onlinePeers.update((set) => new Set([...set, fromAgent]));
+      return;
+    }
+
     if (payload.type === "Message") {
       await conversationMessageStore.handleMessageSignalReceived(
         cellIdB64,
         signal.value.payload as MessageSignal,
       );
-      // Mark conversation as unread
-      // Unless user is currently viewing the conversation page.
       const $page = get(page);
       if ($page.params.id !== cellIdB64 || $page.route.id !== "/conversations/[id]") {
         await conversationStore.updateUnread(cellIdB64, true);


### PR DESCRIPTION
 ## Summary
 
 Closes #69 

  - Show a green dot next to member avatars on the conversation details page when they are connected
  - Uses ping/pong signals via the existing relay zome, no new zomes
  - Dot is only visible when a member is connected, hidden when offline

  ## Approaches considered

  ### 1. `@holochain-open-dev/peer-status` library
  Separate npm package with its own Rust zome and Lit-based UI components.

  **Rejected because:**
  - Built for `@holochain/client ^0.16.0`, we use `0.20.4-rc.0` (incompatible API)
  - Rust crate targets HDK `0.2.3`, we use `0.6.0` (won't compile)
  - Lit UI components, we use Svelte
  - No `main-0.6` branch exists (unlike profiles/file-storage which have compatible branches)

  ### 2. Separate `peer_status` coordinator zome
  New zome added to the relay DNA with its own `recv_remote_signal`.

  **Rejected because:**
  - Adding a new zome changes the DNA hash
 
  ### 3. Transport-level network stats (`dumpNetworkStats`)
  Derive peer status from `transportStats.connections[]` which already polls every 30s.

  **Rejected because:**
  - Transport connections use iroh node IDs, not Holochain agent keys
  - Verified by comparing hex pub_keys from transport with agent keys from profiles, completely different key pairs
  - Cannot map "who is connected" to "which member" without additional data

  ### 4. `agentInfo()` API
  Poll `client.agentInfo()` which returns agent presence data with ~20 min TTL.

  **Rejected because:**
  - Agent info has ~20 min expiry, a member who closes the app still shows as "online" for up to 20 minutes
  - It's a peer discovery mechanism, not a presence mechanism
  - Unreliable for real-time status

  ### 5. Ping/pong via existing relay zome (chosen)
  Extend `recv_remote_signal` in the relay zome to handle PeerPing/PeerPong alongside existing Message signals.

  **Why this approach:**
  - No new zome, no DNA hash change
  - Real-time accuracy, if a peer responds to a ping, they're online right now
  - Follows existing codebase patterns (RelayClient for zome calls, SignalHandler for dispatch, Svelte context for state)

  ## How it works

  1. When user opens conversation details page, `ping_agents` zome call fires every 10s
  2. Remote agents receive PeerPing via `recv_remote_signal`, auto-respond with PeerPong
  3. PeerPong signals arrive back, SignalHandler adds the agent to an `onlinePeers` set
  4. MemberListItem checks if the member is in the set shows green dot if yes
  5. Set is cleared before each ping cycle so offline peers drop off