### PR TITLE
 Fix: Allow package downgrades in Linux CI build

### DIFF
--- a/.github/workflows/release-tauri-app.yaml
+++ b/.github/workflows/release-tauri-app.yaml
@@ -132,7 +132,8 @@ jobs:
 
           # We must pin webkitgtk to 2.44 for x86_64, as we get a blank screen on later versions.
           # See https://github.com/tauri-apps/tauri/issues/12431
-          #
+          # Because libwebkit2gtk-4.1-dev version 2.46 has been removed from the apt repositories,
+          # we must manually download the deb packages from launchpad to install it.
           # Only pin WebKitGTK on amd64 as these are arch-specific deb packages
           if [ "${{ matrix.arch }}" = "x86_64" ]; then
               mkdir -p /tmp/ubuntu-packages
@@ -149,7 +150,7 @@ jobs:
               wget https://launchpadlibrarian.net/595623693/libjpeg8_8c-2ubuntu10_amd64.deb
               wget https://launchpadlibrarian.net/587202140/libjpeg-turbo8_2.1.2-0ubuntu1_amd64.deb
               wget https://launchpadlibrarian.net/592959859/xdg-desktop-portal-gtk_1.14.0-1build1_amd64.deb
-              sudo apt-get install -y /tmp/ubuntu-packages/*.deb
+              sudo apt-get install -y --allow-downgrades /tmp/ubuntu-packages/*.deb
           fi
 
       - name: Install and prepare


### PR DESCRIPTION
* Add --allow-downgrades flag to apt-get install command to fix build failure when pinning WebKitGTK to version 2.44.0 on x86_64, this libraries is upgraded on CI and we need to downgrade it as described.

Change-Id: Ie1c80d0f2000708373eeb626e261a99440c34075

### Summary
- Fixes x86_64 linux builds