### PR TITLE
Chat History Pagination Fix

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "svelte.svelte-vscode",
-    "esbenp.prettier-vscode"
+    "esbenp.prettier-vscode",
+    "saoudrizwan.claude-dev"
   ]
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -652,6 +652,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bimap"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,6 +1007,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2639,6 +2662,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg 1.5.0",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3112,6 +3144,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
 name = "gtk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3288,6 +3331,42 @@ dependencies = [
  "serde_bytes",
  "sodoken",
  "tokio",
+]
+
+[[package]]
+name = "hc_uniffi"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab4511c6ca6b3cbb38f37e97a79c6d8efac7595b44af5f649af492e814efc21d"
+dependencies = [
+ "anyhow",
+ "cargo_metadata 0.15.4",
+ "hc_uniffi_bindgen",
+ "uniffi_core",
+ "uniffi_macros",
+]
+
+[[package]]
+name = "hc_uniffi_bindgen"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bebee6a0234db27946c6983e01f153289dc1e1d48a18277b5fc1e8fd20e73a0"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata 0.15.4",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck 0.5.0",
+ "once_cell",
+ "paste",
+ "rinja",
+ "serde",
+ "textwrap",
+ "toml 0.5.11",
+ "uniffi_meta",
+ "uniffi_udl",
 ]
 
 [[package]]
@@ -3558,6 +3637,19 @@ dependencies = [
  "uuid 1.18.1",
  "wasmer",
  "wasmer-middlewares",
+]
+
+[[package]]
+name = "holochain-conductor-runtime-types-ffi"
+version = "0.3.0"
+source = "git+https://github.com/HelloVolla/volla-cloud-services?tag=android-service-runtime-v0.3.2#d2986027935418d6967d6a52b55bec880af49e66"
+dependencies = [
+ "bytes",
+ "hc_uniffi",
+ "holochain_conductor_api",
+ "holochain_types",
+ "serde",
+ "url2",
 ]
 
 [[package]]
@@ -8239,6 +8331,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "rinja"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc4940d00595430b3d7d5a01f6222b5e5b51395d1120bdb28d854bb8abb17a5"
+dependencies = [
+ "itoa",
+ "rinja_derive",
+]
+
+[[package]]
+name = "rinja_derive"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d9ed0146aef6e2825f1b1515f074510549efba38d71f4554eec32eb36ba18b"
+dependencies = [
+ "basic-toml",
+ "memchr",
+ "mime",
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "rinja_parser",
+ "rustc-hash 2.1.1",
+ "serde",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "rinja_parser"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f9a866e2e00a7a1fb27e46e9e324a6f7c0e7edc4543cae1d38f4e4a100c610"
+dependencies = [
+ "memchr",
+ "nom 7.1.3",
+ "serde",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8659,6 +8790,26 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "sd-notify"
@@ -9195,6 +9346,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
@@ -9935,6 +10092,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-holochain-service-client"
+version = "0.3.0"
+source = "git+https://github.com/HelloVolla/volla-cloud-services?tag=android-service-runtime-v0.3.2#d2986027935418d6967d6a52b55bec880af49e66"
+dependencies = [
+ "bytes",
+ "holochain-conductor-runtime-types-ffi",
+ "serde",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-log"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10088,7 +10258,7 @@ checksum = "219a1f983a2af3653f75b5747f76733b0da7ff03069c7a41901a5eb3ace4557d"
 dependencies = [
  "anyhow",
  "brotli",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "ctor",
  "dunce",
  "glob",
@@ -10180,6 +10350,15 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+]
 
 [[package]]
 name = "thiserror"
@@ -10421,6 +10600,15 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -10835,6 +11023,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "uniffi_core"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c18baace68a52666d33d12d73ca335ecf27a302202cefb53b1f974512bb72417"
+dependencies = [
+ "anyhow",
+ "async-compat",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09acd2ce09c777dd65ee97c251d33c8a972afc04873f1e3b21eb3492ade16933"
+dependencies = [
+ "anyhow",
+ "indexmap 2.11.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d82c82ef945c51082d8763635334b994e63e77650f09d0fae6d28dd08b1de83"
+dependencies = [
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "toml 0.5.11",
+ "uniffi_meta",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d6027b971c2aa86350dd180aee9819729c7b99bacd381534511ff29d2c09cea"
+dependencies = [
+ "anyhow",
+ "siphasher 0.3.11",
+ "uniffi_internal_macros",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52300b7a4ab02dc159a038a13d5bfe27aefbad300d91b0b501b3dda094c1e0a2"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta",
+ "weedle2",
+]
+
+[[package]]
 name = "universal-hash"
 version = "0.6.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11008,7 +11262,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "volla_messages"
-version = "0.11.6"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "app_dirs2",
@@ -11026,6 +11280,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-holochain",
+ "tauri-plugin-holochain-service-client",
  "tauri-plugin-log",
  "tauri-plugin-notification",
  "tauri-plugin-os",
@@ -11619,6 +11874,15 @@ dependencies = [
  "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "weedle2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]

--- a/ui/docs/doc.md
+++ b/ui/docs/doc.md
@@ -124,6 +124,25 @@ Every feature of the app is managed by a store, which is a Svelte Store. Each st
 - `handleMessageDeletedSignalReceived(key, actionHashB64)` handles message deletion signals
 - `subscribe(run)` svelte store subscription for message data
 
+    4.1 **Conversation History Loading & Pagination**
+    - On initialization, recent messages are first hydrated from IndexedDB before requesting more data from Holochain
+    - Recent conversation data is loaded from the current bucket, while older history is loaded through upward pagination
+    - Upward pagination first checks IndexedDB for older cached rows using the current oldest in-memory timestamp as the cursor
+    - If IndexedDB has no older rows, the store fetches previous message buckets from Holochain and stores the results back into IndexedDB
+    - Bucket loading is done in chunks so the UI can progressively load enough history without scanning the full conversation at once
+    - Message fetching uses Holochain bucket based retrieval with `local = true` for fast local-first history access during pagination
+    - Newly fetched records are stored in IndexedDB and then merged into memory, avoiding duplicate inserts
+    - The store tracks pagination state per conversation, including the oldest loaded timestamp and whether local/network history is exhausted
+    - When the earliest available bucket is reached, pagination is marked as exhausted so top-scroll loading stops repeating
+    - A hard in-memory limit is applied to keep only the newest bounded set of messages in memory while older history remains available in IndexedDB
+
+    4.2 **Scroll Behaviour for Older Messages**
+    - The conversation page listens for top-scroll events from the message list to trigger older history loading
+    - Before older messages are prepended, the current top visible message is captured as an anchor
+    - After older messages are inserted, the scroll position is restored relative to that anchor so the viewport does not jump unexpectedly
+    - Once the message history is exhausted, the UI stops requesting further loads from the top-scroll trigger
+
+
 5. **ConversationLatestMessageStore.ts**
 - Provides a derived store that tracks the latest message in each conversation
 - Combines data from the conversation and message stores

--- a/ui/src/routes/conversations/[id]/+page.svelte
+++ b/ui/src/routes/conversations/[id]/+page.svelte
@@ -306,7 +306,7 @@
         <ConversationMessages
           loadingTop={loadingMessagesOld}
           cellIdB64={$page.params.id}
-          messages={$messages.list.reverse()}
+          messages={$messages.list}
           on:delete={(e) => {
             deleteMessageActionHashB64 = e.detail;
             showDeleteDialog = true;

--- a/ui/src/routes/conversations/[id]/+page.svelte
+++ b/ui/src/routes/conversations/[id]/+page.svelte
@@ -91,7 +91,13 @@
   let isFirstProfilesLoad = true;
   let isFirstLoadMessages = true;
 
+  let noMoreOlderMessages = false;
+
   $: iAmProgenitor = $conversation.dnaProperties.progenitor === myPubKeyB64;
+
+  $: if ($page.params.id) {
+  noMoreOlderMessages = false;
+}
 
   async function handleDeleteMessage() {
     if (deleteMessageActionHashB64 === undefined) return;
@@ -162,7 +168,7 @@
   };
 
 async function loadMoreMessages() {
-  if (loadingMessagesOld) return;
+  if (loadingMessagesOld || noMoreOlderMessages) return;
 
   loadingMessagesOld = true;
   userIsPagingHistory = true;
@@ -170,6 +176,11 @@ async function loadMoreMessages() {
   try {
     const loadedCount = await messages.loadMoreMessages();
     console.log("loadedCount:", loadedCount);
+
+    if (loadedCount === 0) {
+      noMoreOlderMessages = true;
+      console.log("History exhausted at UI level");
+    }
   } catch (e) {
     console.error("Error loading more messages:", e);
   } finally {

--- a/ui/src/routes/conversations/[id]/+page.svelte
+++ b/ui/src/routes/conversations/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { decodeHashFromBase64, type ActionHashB64, type AgentPubKeyB64 } from "@holochain/client";
+  import type { ActionHashB64, type AgentPubKeyB64 } from "@holochain/client";
   import { getContext, onDestroy, onMount } from "svelte";
   import { page } from "$app/stores";
   import { goto } from "$app/navigation";
@@ -26,7 +26,6 @@
     type MergedProfileContactInviteJoinedStore,
   } from "$store/MergedProfileContactInviteJoinedStore";
   import { POLLING_INTERVAL_FAST, POLLING_INTERVAL_SLOW } from "$config";
-  import SvgIcon from "$lib/SvgIcon.svelte";
   import DialogConfirm from "$lib/DialogConfirm.svelte";
   import ConversationHeader from "./ConversationHeader.svelte";
   import {
@@ -39,19 +38,25 @@
   const conversationStore = getContext<{ getStore: () => ConversationStore }>(
     "conversationStore",
   ).getStore();
+
   const profileStore = getContext<{ getStore: () => ProfileStore }>("profileStore").getStore();
+
   const mergedProfileContactInviteJoinedStore = getContext<{
     getStore: () => MergedProfileContactInviteJoinedStore;
   }>("mergedProfileContactInviteJoinedStore").getStore();
+
   const myPubKeyB64 = getContext<{ getMyPubKeyB64: () => AgentPubKeyB64 }>(
     "myPubKey",
   ).getMyPubKeyB64();
+
   const conversationTitleStore = getContext<{
     getStore: () => ConversationTitleStore;
   }>("conversationTitleStore").getStore();
+
   const conversationMessageStore = getContext<{
     getStore: () => ConversationMessageStore;
   }>("conversationMessageStore").getStore();
+
   const networkStatsStore = getContext<{
     getStore: () => NetworkStatsStore;
   }>("networkStatsStore").getStore();
@@ -65,19 +70,21 @@
     $page.params.id,
   );
   let conversationNetwork = deriveConversationNetworkStore(networkStatsStore, $page.params.id);
+
   let showConversationNetworkPanel = false;
 
-  let configTimeout: NodeJS.Timeout;
-  let agentTimeout: NodeJS.Timeout;
-  let messageTimeout: NodeJS.Timeout;
+  let configTimeout: ReturnType<typeof setTimeout>;
+  let agentTimeout: ReturnType<typeof setTimeout>;
+  let messageTimeout: ReturnType<typeof setTimeout>;
 
   let conversationMessageInputRef: HTMLInputElement;
   let sending = false;
   let loadingMessagesNew = false;
   let loadingMessagesOld = false;
+  let userIsPagingHistory = false;
 
   let showDeleteDialog = false;
-  let deleteMessageActionHashB64: undefined | ActionHashB64 = undefined;
+  let deleteMessageActionHashB64: ActionHashB64 | undefined = undefined;
   let isDeletingMessage = false;
 
   let isFirstConfigLoad = true;
@@ -91,7 +98,7 @@
 
     isDeletingMessage = true;
     try {
-      await messages.deleteMessage($page.params.id, deleteMessageActionHashB64);
+      await messages.deleteMessage(deleteMessageActionHashB64);
       toast.success($t("common.delete_message_success"));
     } catch (err) {
       console.error(err);
@@ -102,11 +109,8 @@
     deleteMessageActionHashB64 = undefined;
   }
 
-  /**
-   * Fetch agent profiles every 2s, until at least 2 profiles are received.
-   */
   async function loadProfiles() {
-    await profiles.load(true); 
+    await profiles.load(true);
     isFirstProfilesLoad = false;
     clearTimeout(agentTimeout);
 
@@ -121,14 +125,8 @@
     }
   }
 
-  /**
-   * Fetch config every 2s, until it is received.
-   *
-   * Note that if the config is updated, the latest version will not appear until
-   * navigating away from and back to this page.
-   */
   async function loadConfig() {
-    await conversation.loadConfig(true); 
+    await conversation.loadConfig(true);
     isFirstConfigLoad = false;
     clearTimeout(configTimeout);
 
@@ -143,23 +141,18 @@
     }
   }
 
-  /**
-   * Fetch messages from current bucket every 2s, until any messages are received.
-   */
   async function loadMessages() {
-    clearTimeout(messageTimeout);
-    await loadMessagesInCurrentBucket(true); // allways load local because we don't want to trigger a network get that can take a long time.
-    isFirstLoadMessages = false;
+     clearTimeout(messageTimeout);
 
-    if ($messages.count === 0) {
-      messageTimeout = setTimeout(() => {
-        loadMessages();
-      }, POLLING_INTERVAL_FAST);
-    } else {
-      messageTimeout = setTimeout(() => {
-        loadMessages();
-      }, POLLING_INTERVAL_SLOW);
-    }
+  if (!loadingMessagesOld && !userIsPagingHistory && !loadingMessagesNew) {
+    await loadMessagesInCurrentBucket(true);
+    isFirstLoadMessages = false;
+  }
+
+  messageTimeout = setTimeout(
+    loadMessages,
+    $messages.count === 0 ? POLLING_INTERVAL_FAST : POLLING_INTERVAL_SLOW,
+  );
   }
 
   const loadData = () => {
@@ -168,33 +161,29 @@
     loadMessages();
   };
 
-  async function loadMessagesInPreviousBucket() {
-    if (loadingMessagesOld) return;
+async function loadMoreMessages() {
+  if (loadingMessagesOld) return;
 
-    loadingMessagesOld = true;
-    try {
-      await messages.loadMessagesInPreviousBucketTargetCount(true); // allways load local because we don't want to trigger a network get that can take a long time.
-    } catch (e) {
-      console.error(e);
-    }
+  loadingMessagesOld = true;
+  userIsPagingHistory = true;
+
+  try {
+    const loadedCount = await messages.loadMoreMessages();
+    console.log("loadedCount:", loadedCount);
+  } catch (e) {
+    console.error("Error loading more messages:", e);
+  } finally {
     loadingMessagesOld = false;
-  }
 
-  async function loadMoreMessages() {
-    if (loadingMessagesOld) return;
-
-    loadingMessagesOld = true;
-    try {
-      const loadedCount = await messages.loadMoreMessages();
-      console.log(`Loaded ${loadedCount} more messages for infinite scroll`);
-    } catch (e) {
-      console.error("Error loading more messages:", e);
-    }
-    loadingMessagesOld = false;
+    setTimeout(() => {
+      userIsPagingHistory = false;
+    }, 1200);
   }
+}
 
   async function loadMessagesInCurrentBucket(local: boolean) {
     if (loadingMessagesNew) return;
+
     console.log("loadMessagesInCurrentBucket");
     loadingMessagesNew = true;
     try {
@@ -208,8 +197,7 @@
   async function sendMessage(text: string, files: LocalFile[]) {
     if (sending) return;
 
-    // Focus on input field to ensure the keyboard remains open after sending message on android
-    conversationMessageInputRef.focus();
+    conversationMessageInputRef?.focus();
 
     sending = true;
     try {
@@ -222,14 +210,11 @@
   }
 
   onMount(() => {
-    conversationMessageInputRef.focus();
-
+    conversationMessageInputRef?.focus();
     loadData();
-
     conversation.updateUnread(false);
   });
 
-  // Cleanup
   onDestroy(() => {
     clearTimeout(agentTimeout);
     clearTimeout(configTimeout);
@@ -238,13 +223,11 @@
 
   async function dumpAll() {
     console.log("Dumping all");
-    
-    // Import and dump IndexedDB contents
+
     const { messageDB } = await import("$store/db/MessageDatabase");
     await messageDB.debugDumpAll();
-    
-    // Also get all messages from Holochain
-    messages.debugGetAllMessages();
+
+    await messages.debugGetAllMessages();
   }
 </script>
 
@@ -295,13 +278,10 @@
 <div class="mx-auto flex w-full flex-1 flex-col items-center justify-center overflow-hidden">
   <div class="relative flex w-full grow flex-col items-center overflow-hidden pt-6">
     {#if $messages.count === 0 && iAmProgenitor && $joined.count === 1}
-      <!-- No messages yet, no one has joined, and this is a conversation I created. Display a helpful message to invite others -->
       <ConversationEmpty cellIdB64={$page.params.id} />
     {:else if $messages.count === 0}
-      <!-- No messages yet, display conversation header -->
       <ConversationHeader cellIdB64={$page.params.id} />
     {:else}
-      <!-- Display conversation messages with proper height container -->
       <div class="w-full flex-1 overflow-hidden">
         <ConversationMessages
           loadingTop={loadingMessagesOld}

--- a/ui/src/routes/conversations/[id]/ConversationMessages.svelte
+++ b/ui/src/routes/conversations/[id]/ConversationMessages.svelte
@@ -6,7 +6,7 @@
   import NoticeMessage from "./NoticeMessage.svelte";
   import ConversationHeader from "./ConversationHeader.svelte";
   import { createVirtualizer } from "@tanstack/svelte-virtual";
-  import { afterUpdate, beforeUpdate, createEventDispatcher, onMount, tick } from "svelte";
+  import { afterUpdate, createEventDispatcher, onMount, tick } from "svelte";
 
   const dispatch = createEventDispatcher<{
     scrollAtTop: null;
@@ -23,14 +23,10 @@
 
   $: chronologicalMessages = messages;
 
-  // Update virtualizer count when messages change
-  $: if ($virtualizer) {
-    $virtualizer.setOptions({ count: chronologicalMessages?.length });
-  }
   const MESSAGE_FIXED_HEIGHT = 40;
   const UPDATE_TRIGGER_VIEW_OFFSET = 1000;
   const BUFFER_COUNT = 10;
-  const SCROLL_DEBOUNCE_MS = 150; // Debounce scroll events to prevent multiple triggers
+  const SCROLL_DEBOUNCE_MS = 150;
 
   let virtualizer = createVirtualizer({
     count: chronologicalMessages?.length,
@@ -39,6 +35,7 @@
     overscan: BUFFER_COUNT,
     useAnimationFrameWithResizeObserver: true,
   });
+
   // Update virtualizer count when messages change
   $: if ($virtualizer) $virtualizer.setOptions({ count: chronologicalMessages?.length });
 
@@ -64,46 +61,48 @@
 
   let isAtBottom = true;
   let wasAtBottom = true;
-  let isAtTop = false;
-  let wasAtTop = false;
   let scrollDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+  // ── Scroll-anchor state for prepending older messages ──
+  let anchorScrollTop = 0;
+  let anchorScrollHeight = 0;
+  let needsScrollAnchor = false;
+  let previousItemCount = 0;
+  // Track whether the previous loadingTop was true so we can detect the
+  // transition from loading → done and apply the scroll anchor at that moment.
+  let prevLoadingTop = false;
 
   onMount(async () => {
     if (chronologicalMessages.length > 0 && containerEl) {
       isAtBottom = true;
       wasAtBottom = true;
-      isAtTop = false;
-      wasAtTop = false;
-
       await scrollToBottom();
     }
   });
 
-  let previousScrollHeight = 0;
-  let previousScrollTop = 0;
-  let previousItemCount = 0;
-  let shouldMaintainScroll = false;
-  // let isFirstFetch = true;
-
-
-beforeUpdate(() => {
-    if (shouldMaintainScroll && containerEl && previousScrollHeight === 0) {
-      previousScrollHeight = containerEl.scrollHeight;
-      previousScrollTop = containerEl.scrollTop;
+  // ── Scroll-anchor restoration ──
+  // We captured scrollTop / scrollHeight *before* the load started (no spinner,
+  // fewer messages).  We restore when the load finishes (loadingTop transitions
+  // true → false) so the spinner height cancels out and we only compensate for
+  // the new messages that were prepended.
+  //
+  // IMPORTANT: needsScrollAnchor must be cleared *before* assigning scrollTop.
+  // Setting scrollTop fires the scroll event synchronously in the browser.
+  // If needsScrollAnchor were still true at that point, handleScroll would see
+  // it and skip the debounce, leaving the user stranded in the trigger zone
+  // without an automatic re-trigger for the next page.
+  afterUpdate(() => {
+    if (needsScrollAnchor && containerEl && prevLoadingTop && !loadingTop) {
+      const newScrollHeight = containerEl.scrollHeight;
+      const heightDiff = newScrollHeight - anchorScrollHeight;
+      // Clear the flag first so the synchronous scroll event fired by the
+      // scrollTop assignment below can start the next debounce immediately.
+      needsScrollAnchor = false;
+      if (heightDiff > 0) {
+        containerEl.scrollTop = anchorScrollTop + heightDiff;
+      }
     }
-  });
-
-afterUpdate(() => {
-    if (shouldMaintainScroll && !loadingTop && containerEl && previousScrollHeight > 0) {
-      const heightDifference = containerEl.scrollHeight - previousScrollHeight;
-      
-      // Seamlessly shift the scrollbar down by the exact height of the new messages
-      containerEl.scrollTop = previousScrollTop + heightDifference;
-
-      // Reset the locks for the next time the user scrolls up
-      shouldMaintainScroll = false;
-      previousScrollHeight = 0;
-    }
+    prevLoadingTop = loadingTop;
   });
 
   function handleScroll() {
@@ -112,32 +111,38 @@ afterUpdate(() => {
     const { scrollTop, scrollHeight, clientHeight } = containerEl;
     const scrollBottom = scrollHeight - scrollTop - clientHeight;
 
-    const isAtBottom = scrollBottom < 5;
-    const isAtTop = scrollTop <= UPDATE_TRIGGER_VIEW_OFFSET;
+    const atBottom = scrollBottom < 5;
+    const atTop = scrollTop <= UPDATE_TRIGGER_VIEW_OFFSET;
 
-    // Trigger Infinite Scroll
-    if (isAtTop && !wasAtTop && !loadingTop) {
+    // Trigger infinite-scroll when near the top.
+    // Guards: not already loading, no pending anchor restoration.
+    if (atTop && !loadingTop && !needsScrollAnchor) {
       if (scrollDebounceTimer) clearTimeout(scrollDebounceTimer);
-      
+
       scrollDebounceTimer = setTimeout(() => {
-        shouldMaintainScroll = true;
+        // Capture scroll state *before* the spinner appears or data loads
+        if (containerEl) {
+          anchorScrollTop = containerEl.scrollTop;
+          anchorScrollHeight = containerEl.scrollHeight;
+          needsScrollAnchor = true;
+        }
         dispatch("scrollAtTop");
         scrollDebounceTimer = undefined;
       }, SCROLL_DEBOUNCE_MS);
     }
 
-    wasAtBottom = isAtBottom;
-    wasAtTop = isAtTop;
+    wasAtBottom = atBottom;
   }
 
-  // logic for triggering fetch event, newly_added_items-scroll-down logic
- $: {
- const currentItemCount = chronologicalMessages?.length || 0;
-    
-    if (initialScrollReady && wasAtBottom && currentItemCount > previousItemCount) {
+  // Auto-scroll to bottom when new messages arrive while the user was already
+  // at the bottom (e.g. incoming message or own send).
+  $: {
+    const currentItemCount = chronologicalMessages?.length || 0;
+
+    if (initialScrollReady && wasAtBottom && currentItemCount > previousItemCount && !needsScrollAnchor) {
       scrollToBottom("smooth");
     }
-    
+
     previousItemCount = currentItemCount;
   }
 

--- a/ui/src/routes/conversations/[id]/ConversationMessages.svelte
+++ b/ui/src/routes/conversations/[id]/ConversationMessages.svelte
@@ -23,7 +23,10 @@
 
   $: chronologicalMessages = messages;
 
-  const MESSAGE_FIXED_HEIGHT = 40;
+  // A conservatively large estimated height. Real heights are measured
+  // by ResizeObserver; this value only affects the very first render frame.
+  const MESSAGE_ESTIMATED_HEIGHT = 80;
+  // How close to the top (px) before we start loading older messages.
   const UPDATE_TRIGGER_VIEW_OFFSET = 1000;
   const BUFFER_COUNT = 10;
   const SCROLL_DEBOUNCE_MS = 150;
@@ -31,75 +34,77 @@
   let virtualizer = createVirtualizer({
     count: chronologicalMessages?.length,
     getScrollElement: () => containerEl,
-    estimateSize: () => MESSAGE_FIXED_HEIGHT,
+    estimateSize: () => MESSAGE_ESTIMATED_HEIGHT,
     overscan: BUFFER_COUNT,
     useAnimationFrameWithResizeObserver: true,
   });
 
-  // Update virtualizer count when messages change
   $: if ($virtualizer) $virtualizer.setOptions({ count: chronologicalMessages?.length });
 
   function measure(node: HTMLElement) {
     const index = Number(node.dataset.index);
     if (isNaN(index)) return;
-
     if (!$virtualizer) return;
+
     const observer = new ResizeObserver(() => {
       requestAnimationFrame(() => {
         $virtualizer.measureElement(node);
       });
     });
-
     observer.observe(node);
 
-    return {
-      destroy() {
-        observer.disconnect();
-      },
-    };
+    return { destroy() { observer.disconnect(); } };
   }
 
-  let isAtBottom = true;
   let wasAtBottom = true;
   let scrollDebounceTimer: ReturnType<typeof setTimeout> | undefined;
-
-  // ── Scroll-anchor state for prepending older messages ──
-  let anchorScrollTop = 0;
-  let anchorScrollHeight = 0;
-  let needsScrollAnchor = false;
   let previousItemCount = 0;
-  // Track whether the previous loadingTop was true so we can detect the
-  // transition from loading → done and apply the scroll anchor at that moment.
+
+  // ── Scroll-up anchor ────────────────────────────────────────────────────────
+  //
+  // Instead of raw scrollHeight arithmetic (which relies on estimated heights
+  // that are inaccurate until ResizeObserver fires), we anchor to the HASH of
+  // the first item visible at the trigger moment.  After older messages are
+  // prepended and measured, we call virtualizer.scrollToIndex() for that item's
+  // new index, which uses the virtualizer's own (measurement-aware) positioning.
+  //
+  // Flow:
+  //   1. debounce fires → capture anchorHash = first-visible item hash
+  //                      → needsScrollAnchor = true, dispatch("scrollAtTop")
+  //   2. loadMoreMessages runs (loadingTop: false→true→false)
+  //   3. afterUpdate detects the false→true→false transition
+  //      → find anchorHash's new index in chronologicalMessages
+  //      → scrollToIndex(newIndex, { align:'start' })
+  //
+  // Clearing needsScrollAnchor before scrollToIndex ensures the synchronous
+  // scroll event from scrollToIndex can safely restart the debounce.
+  // ──────────────────────────────────────────────────────────────────────────
+  let anchorHash: ActionHashB64 | null = null;
+  let needsScrollAnchor = false;
   let prevLoadingTop = false;
 
   onMount(async () => {
     if (chronologicalMessages.length > 0 && containerEl) {
-      isAtBottom = true;
       wasAtBottom = true;
       await scrollToBottom();
     }
   });
 
-  // ── Scroll-anchor restoration ──
-  // We captured scrollTop / scrollHeight *before* the load started (no spinner,
-  // fewer messages).  We restore when the load finishes (loadingTop transitions
-  // true → false) so the spinner height cancels out and we only compensate for
-  // the new messages that were prepended.
-  //
-  // IMPORTANT: needsScrollAnchor must be cleared *before* assigning scrollTop.
-  // Setting scrollTop fires the scroll event synchronously in the browser.
-  // If needsScrollAnchor were still true at that point, handleScroll would see
-  // it and skip the debounce, leaving the user stranded in the trigger zone
-  // without an automatic re-trigger for the next page.
   afterUpdate(() => {
-    if (needsScrollAnchor && containerEl && prevLoadingTop && !loadingTop) {
-      const newScrollHeight = containerEl.scrollHeight;
-      const heightDiff = newScrollHeight - anchorScrollHeight;
-      // Clear the flag first so the synchronous scroll event fired by the
-      // scrollTop assignment below can start the next debounce immediately.
+    // Detect the loadingTop true→false transition (load just completed).
+    if (needsScrollAnchor && prevLoadingTop && !loadingTop && anchorHash) {
+      const newIndex = chronologicalMessages.findIndex(([hash]) => hash === anchorHash);
+
+      // Clear before scrollToIndex so the resulting scroll event can
+      // immediately restart the debounce for the next page.
       needsScrollAnchor = false;
-      if (heightDiff > 0) {
-        containerEl.scrollTop = anchorScrollTop + heightDiff;
+      anchorHash = null;
+
+      if (newIndex >= 0) {
+        // scrollToIndex is measurement-aware: it uses the virtualizer's
+        // internally cached item sizes (updated by ResizeObserver), not
+        // the raw estimated heights.
+        $virtualizer.scrollToIndex(newIndex, { align: "start", behavior: "auto" });
       }
     }
     prevLoadingTop = loadingTop;
@@ -114,18 +119,29 @@
     const atBottom = scrollBottom < 5;
     const atTop = scrollTop <= UPDATE_TRIGGER_VIEW_OFFSET;
 
-    // Trigger infinite-scroll when near the top.
-    // Guards: not already loading, no pending anchor restoration.
+    // Trigger infinite-scroll upward.
+    // Guards: not already loading, no pending anchor restore.
     if (atTop && !loadingTop && !needsScrollAnchor) {
       if (scrollDebounceTimer) clearTimeout(scrollDebounceTimer);
 
       scrollDebounceTimer = setTimeout(() => {
-        // Capture scroll state *before* the spinner appears or data loads
-        if (containerEl) {
-          anchorScrollTop = containerEl.scrollTop;
-          anchorScrollHeight = containerEl.scrollHeight;
-          needsScrollAnchor = true;
+        // Capture the first visible item's hash as the scroll anchor.
+        // This is measurement-independent: we scroll to this item's new
+        // index after the load, regardless of estimated item heights.
+        if (containerEl && $virtualizer) {
+          const items = $virtualizer.getVirtualItems();
+          // Find the first item whose bottom edge is past the scrollTop
+          // (i.e., actually in the viewport, not just overscan).
+          const currentScrollTop = containerEl.scrollTop;
+          const firstVisible = items.find(
+            (item) => item.start + item.size > currentScrollTop,
+          );
+          if (firstVisible != null) {
+            anchorHash = chronologicalMessages[firstVisible.index]?.[0] ?? null;
+          }
         }
+
+        needsScrollAnchor = true;
         dispatch("scrollAtTop");
         scrollDebounceTimer = undefined;
       }, SCROLL_DEBOUNCE_MS);
@@ -134,12 +150,16 @@
     wasAtBottom = atBottom;
   }
 
-  // Auto-scroll to bottom when new messages arrive while the user was already
-  // at the bottom (e.g. incoming message or own send).
+  // Auto-scroll to bottom when new messages arrive while the user is at bottom.
   $: {
     const currentItemCount = chronologicalMessages?.length || 0;
 
-    if (initialScrollReady && wasAtBottom && currentItemCount > previousItemCount && !needsScrollAnchor) {
+    if (
+      initialScrollReady &&
+      wasAtBottom &&
+      currentItemCount > previousItemCount &&
+      !needsScrollAnchor
+    ) {
       scrollToBottom("smooth");
     }
 
@@ -152,22 +172,15 @@
     const lastIndex = chronologicalMessages.length - 1;
     if (lastIndex < 0) return;
 
+    // Overshoot to guarantee we land at the very bottom of the container.
     let attempts = 0;
     while (attempts < 5) {
-      // making sure the initial scroll lands completely at bottom edge of the container
-      $virtualizer.scrollToIndex(lastIndex + 999, {
-        align: "start",
-        behavior,
-      });
-
+      $virtualizer.scrollToIndex(lastIndex + 999, { align: "start", behavior });
       await new Promise((resolve) => setTimeout(resolve, 50));
-
       attempts++;
     }
 
-    requestAnimationFrame(() => {
-      initialScrollReady = true;
-    });
+    requestAnimationFrame(() => { initialScrollReady = true; });
   }
 
   async function waitForListLoad() {
@@ -176,14 +189,12 @@
     return new Promise((resolve) => {
       const check = () => {
         const lastIndex = chronologicalMessages?.length - 1;
-
         if ($virtualizer.getVirtualItems().length > 0 && lastIndex >= 0) {
           resolve({});
         } else {
-          requestAnimationFrame(check); // keep checking on next frame
+          requestAnimationFrame(check);
         }
       };
-
       check();
     });
   }
@@ -193,38 +204,29 @@
     selected = selected === actionHashB64 ? undefined : isMobile() ? undefined : actionHashB64;
   }
 
-  function handleClickOutside() {
-    selected = undefined;
-  }
+  function handleClickOutside() { selected = undefined; }
 
   function handlePress(actionHashB64: ActionHashB64) {
-    if (isMobile()) {
-      selected = actionHashB64;
-    }
+    if (isMobile()) selected = actionHashB64;
   }
 
   function shouldShowDaySeparator(currentIndex: number) {
     if (currentIndex === 0) return true;
-
     const currentMsg = chronologicalMessages?.[currentIndex]?.[1];
     const prevMsg = chronologicalMessages?.[currentIndex - 1]?.[1];
-
     if (!currentMsg || !prevMsg) return true;
-
-    return !isSameDay(new Date(currentMsg.timestamp / 1000), new Date(prevMsg.timestamp / 1000));
+    return !isSameDay(
+      new Date(currentMsg.timestamp / 1000),
+      new Date(prevMsg.timestamp / 1000),
+    );
   }
 
   function shouldShowAuthor(currentIndex: number) {
     if (currentIndex === 0) return true;
-
     const currentMsg = chronologicalMessages[currentIndex][1];
     const prevMsg = chronologicalMessages[currentIndex - 1][1];
-
     if (!currentMsg || !prevMsg) return true;
-
-    // Always show author after a system notice
     if (prevMsg.message.message_type === MessageType.System) return true;
-
     return (
       currentMsg.authorAgentPubKeyB64 !== prevMsg.authorAgentPubKeyB64 ||
       !isWithinFiveMinutes(
@@ -245,16 +247,15 @@
   <ConversationHeader {cellIdB64} />
   <div class="flex h-4 items-center justify-center"></div>
 
-   <!-- Loading indicator when fetching older messages -->
+  <!-- Loading indicator when fetching older messages -->
   {#if loadingTop}
     <div class="flex h-12 items-center justify-center">
       <div class="h-6 w-6 animate-spin rounded-full border-2 border-primary-500 border-t-transparent"></div>
     </div>
   {/if}
 
-  <!-- This inner div effectively holds the virtualizer's content scroll height -->
+  <!-- Virtualizer content container -->
   <div style="height: {$virtualizer.getTotalSize()}px; position: relative; width: 100%;">
-    <!-- Virtualized message items -->
     {#each $virtualizer.getVirtualItems() as virtualRow (virtualRow.key)}
       {@const currentIndex = virtualRow.index}
       {@const [actionHashB64, messageExtended] = chronologicalMessages[currentIndex]}
@@ -265,7 +266,6 @@
         use:measure
       >
         <div class="flex flex-shrink-0 flex-col">
-          <!-- Day separator -->
           {#if shouldShowDaySeparator(currentIndex)}
             <div class="text-secondary-400 dark:text-secondary-300 my-4 px-4 text-center text-xs">
               {new Date(messageExtended.timestamp / 1000).toLocaleDateString("en-US", {
@@ -276,7 +276,6 @@
             </div>
           {/if}
 
-          <!-- Message content -->
           {#if messageExtended.message.message_type === MessageType.System}
             <NoticeMessage {cellIdB64} message={messageExtended} />
           {:else}
@@ -295,7 +294,6 @@
             </div>
           {/if}
 
-          <!-- Padding at the very end of the chat -->
           {#if currentIndex === chronologicalMessages?.length - 1}
             <div class="flex h-4 items-center justify-center"></div>
           {/if}

--- a/ui/src/routes/conversations/[id]/ConversationMessages.svelte
+++ b/ui/src/routes/conversations/[id]/ConversationMessages.svelte
@@ -5,7 +5,6 @@
   import BaseMessage from "./Message.svelte";
   import NoticeMessage from "./NoticeMessage.svelte";
   import ConversationHeader from "./ConversationHeader.svelte";
-  import { createVirtualizer } from "@tanstack/svelte-virtual";
   import { afterUpdate, createEventDispatcher, onMount, tick } from "svelte";
 
   const dispatch = createEventDispatcher<{
@@ -21,181 +20,208 @@
   let containerEl: HTMLDivElement | null = null;
   let initialScrollReady = false;
 
-  $: chronologicalMessages = messages;
+  $: chronologicalMessages = messages ?? [];
 
-  // A conservatively large estimated height. Real heights are measured
-  // by ResizeObserver; this value only affects the very first render frame.
-  const MESSAGE_ESTIMATED_HEIGHT = 80;
-  // How close to the top (px) before we start loading older messages.
-  const UPDATE_TRIGGER_VIEW_OFFSET = 1000;
-  const BUFFER_COUNT = 10;
-  const SCROLL_DEBOUNCE_MS = 150;
-
-  let virtualizer = createVirtualizer({
-    count: chronologicalMessages?.length,
-    getScrollElement: () => containerEl,
-    estimateSize: () => MESSAGE_ESTIMATED_HEIGHT,
-    overscan: BUFFER_COUNT,
-    useAnimationFrameWithResizeObserver: true,
-  });
-
-  $: if ($virtualizer) $virtualizer.setOptions({ count: chronologicalMessages?.length });
-
-  function measure(node: HTMLElement) {
-    const index = Number(node.dataset.index);
-    if (isNaN(index)) return;
-    if (!$virtualizer) return;
-
-    const observer = new ResizeObserver(() => {
-      requestAnimationFrame(() => {
-        $virtualizer.measureElement(node);
-      });
-    });
-    observer.observe(node);
-
-    return { destroy() { observer.disconnect(); } };
-  }
+  const TOP_TRIGGER_PX = 160;
+  const BOTTOM_EPSILON_PX = 8;
+  const SCROLL_DEBOUNCE_MS = 120;
 
   let wasAtBottom = true;
-  let scrollDebounceTimer: ReturnType<typeof setTimeout> | undefined;
   let previousItemCount = 0;
+  let scrollDebounceTimer: ReturnType<typeof setTimeout> | undefined;
 
-  // ── Scroll-up anchor ────────────────────────────────────────────────────────
-  //
-  // Instead of raw scrollHeight arithmetic (which relies on estimated heights
-  // that are inaccurate until ResizeObserver fires), we anchor to the HASH of
-  // the first item visible at the trigger moment.  After older messages are
-  // prepended and measured, we call virtualizer.scrollToIndex() for that item's
-  // new index, which uses the virtualizer's own (measurement-aware) positioning.
-  //
-  // Flow:
-  //   1. debounce fires → capture anchorHash = first-visible item hash
-  //                      → needsScrollAnchor = true, dispatch("scrollAtTop")
-  //   2. loadMoreMessages runs (loadingTop: false→true→false)
-  //   3. afterUpdate detects the false→true→false transition
-  //      → find anchorHash's new index in chronologicalMessages
-  //      → scrollToIndex(newIndex, { align:'start' })
-  //
-  // Clearing needsScrollAnchor before scrollToIndex ensures the synchronous
-  // scroll event from scrollToIndex can safely restart the debounce.
-  // ──────────────────────────────────────────────────────────────────────────
   let anchorHash: ActionHashB64 | null = null;
-  let needsScrollAnchor = false;
+  let anchorTopBeforeLoad = 0;
+  let pendingAnchorRestore = false;
   let prevLoadingTop = false;
+
+  const rowElements = new Map<ActionHashB64, HTMLElement>();
+
+  $: {
+  console.log("[ConversationMessages] received messages:", chronologicalMessages.length);
+  if (chronologicalMessages.length > 0) {
+    console.log("[ConversationMessages] oldest:", {
+      hash: chronologicalMessages[0][0],
+      timestamp: chronologicalMessages[0][1].timestamp,
+      bucket: chronologicalMessages[0][1].message.bucket,
+    });
+    console.log("[ConversationMessages] newest:", {
+      hash: chronologicalMessages[chronologicalMessages.length - 1][0],
+      timestamp: chronologicalMessages[chronologicalMessages.length - 1][1].timestamp,
+      bucket: chronologicalMessages[chronologicalMessages.length - 1][1].message.bucket,
+    });
+  }
+}
+
+function registerRow(node: HTMLElement, hash: ActionHashB64) {
+  rowElements.set(hash, node);
+
+  return {
+    update(newHash: ActionHashB64) {
+      if (newHash !== hash) {
+        rowElements.delete(hash);
+        hash = newHash;
+        rowElements.set(hash, node);
+      }
+    },
+    destroy() {
+      rowElements.delete(hash);
+    },
+  };
+}
+
+  function clearScrollDebounce() {
+    if (scrollDebounceTimer) {
+      clearTimeout(scrollDebounceTimer);
+      scrollDebounceTimer = undefined;
+    }
+  }
+
+  function getDistanceFromBottom() {
+    if (!containerEl) return 0;
+    return containerEl.scrollHeight - containerEl.scrollTop - containerEl.clientHeight;
+  }
+
+  function updateBottomState() {
+    wasAtBottom = getDistanceFromBottom() <= BOTTOM_EPSILON_PX;
+  }
+
+  function getFirstVisibleAnchor(): { hash: ActionHashB64; top: number } | null {
+    if (!containerEl) return null;
+
+    const containerTop = containerEl.getBoundingClientRect().top;
+    for (const [hash] of chronologicalMessages) {
+      const node = rowElements.get(hash);
+      if (!node) continue;
+
+      const rect = node.getBoundingClientRect();
+      if (rect.bottom > containerTop) {
+        return {
+          hash,
+          top: rect.top - containerTop,
+        };
+      }
+    }
+
+    return null;
+  }
+
+  async function restoreAnchorPosition() {
+    if (!containerEl || !anchorHash) return;
+
+    await tick();
+
+    let attempts = 0;
+    while (attempts < 8) {
+      const node = rowElements.get(anchorHash);
+      if (node) {
+        const containerTop = containerEl.getBoundingClientRect().top;
+        const currentTop = node.getBoundingClientRect().top - containerTop;
+        const delta = currentTop - anchorTopBeforeLoad;
+        containerEl.scrollTop += delta;
+          console.log("[ConversationMessages] anchor restored", {
+          anchorHash,
+          currentTop,
+          anchorTopBeforeLoad,
+          delta,
+          newScrollTop: containerEl.scrollTop,
+        });
+        break;
+      }
+
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+      attempts++;
+    }
+
+    pendingAnchorRestore = false;
+    anchorHash = null;
+  }
 
   onMount(async () => {
     if (chronologicalMessages.length > 0 && containerEl) {
-      wasAtBottom = true;
-      await scrollToBottom();
+      await scrollToBottom("auto");
+      updateBottomState();
+    } else {
+      initialScrollReady = true;
     }
   });
 
-  afterUpdate(() => {
-    // Detect the loadingTop true→false transition (load just completed).
-    if (needsScrollAnchor && prevLoadingTop && !loadingTop && anchorHash) {
-      const newIndex = chronologicalMessages.findIndex(([hash]) => hash === anchorHash);
-
-      // Clear before scrollToIndex so the resulting scroll event can
-      // immediately restart the debounce for the next page.
-      needsScrollAnchor = false;
-      anchorHash = null;
-
-      if (newIndex >= 0) {
-        // scrollToIndex is measurement-aware: it uses the virtualizer's
-        // internally cached item sizes (updated by ResizeObserver), not
-        // the raw estimated heights.
-        $virtualizer.scrollToIndex(newIndex, { align: "start", behavior: "auto" });
-      }
+  afterUpdate(async () => {
+    if (pendingAnchorRestore && prevLoadingTop && !loadingTop) {
+      await restoreAnchorPosition();
+      updateBottomState();
     }
+
     prevLoadingTop = loadingTop;
   });
 
   function handleScroll() {
     if (!containerEl || !initialScrollReady) return;
 
-    const { scrollTop, scrollHeight, clientHeight } = containerEl;
-    const scrollBottom = scrollHeight - scrollTop - clientHeight;
+    updateBottomState();
 
-    const atBottom = scrollBottom < 5;
-    const atTop = scrollTop <= UPDATE_TRIGGER_VIEW_OFFSET;
-
-    // Trigger infinite-scroll upward.
-    // Guards: not already loading, no pending anchor restore.
-    if (atTop && !loadingTop && !needsScrollAnchor) {
-      if (scrollDebounceTimer) clearTimeout(scrollDebounceTimer);
-
-      scrollDebounceTimer = setTimeout(() => {
-        // Capture the first visible item's hash as the scroll anchor.
-        // This is measurement-independent: we scroll to this item's new
-        // index after the load, regardless of estimated item heights.
-        if (containerEl && $virtualizer) {
-          const items = $virtualizer.getVirtualItems();
-          // Find the first item whose bottom edge is past the scrollTop
-          // (i.e., actually in the viewport, not just overscan).
-          const currentScrollTop = containerEl.scrollTop;
-          const firstVisible = items.find(
-            (item) => item.start + item.size > currentScrollTop,
-          );
-          if (firstVisible != null) {
-            anchorHash = chronologicalMessages[firstVisible.index]?.[0] ?? null;
-          }
-        }
-
-        needsScrollAnchor = true;
-        dispatch("scrollAtTop");
-        scrollDebounceTimer = undefined;
-      }, SCROLL_DEBOUNCE_MS);
+    if (wasAtBottom) {
+      dispatch("scrollAtBottom");
     }
 
-    wasAtBottom = atBottom;
+    const atTop = containerEl.scrollTop <= TOP_TRIGGER_PX;
+    if (!atTop || loadingTop || pendingAnchorRestore) {
+      clearScrollDebounce();
+      return;
+    }
+
+    clearScrollDebounce();
+    scrollDebounceTimer = setTimeout(() => {
+      if (!containerEl || loadingTop || pendingAnchorRestore) return;
+      if (containerEl.scrollTop > TOP_TRIGGER_PX) return;
+
+      const anchor = getFirstVisibleAnchor();
+      if (anchor) {
+        anchorHash = anchor.hash;
+        anchorTopBeforeLoad = anchor.top;
+        pendingAnchorRestore = true;
+      }
+console.log("[ConversationMessages] scrollAtTop fired", {
+  scrollTop: containerEl?.scrollTop,
+  currentCount: chronologicalMessages.length,
+  anchorHash,
+  anchorTopBeforeLoad,
+  loadingTop,
+  pendingAnchorRestore,
+});
+      dispatch("scrollAtTop");
+      scrollDebounceTimer = undefined;
+    }, SCROLL_DEBOUNCE_MS);
   }
 
-  // Auto-scroll to bottom when new messages arrive while the user is at bottom.
   $: {
-    const currentItemCount = chronologicalMessages?.length || 0;
+    const currentItemCount = chronologicalMessages.length;
 
     if (
       initialScrollReady &&
       wasAtBottom &&
       currentItemCount > previousItemCount &&
-      !needsScrollAnchor
+      !loadingTop &&
+      !pendingAnchorRestore
     ) {
-      scrollToBottom("smooth");
+      scrollToBottom("auto");
     }
 
     previousItemCount = currentItemCount;
   }
 
-  async function scrollToBottom(behavior?: "auto" | "smooth") {
-    await waitForListLoad();
-
-    const lastIndex = chronologicalMessages.length - 1;
-    if (lastIndex < 0) return;
-
-    // Overshoot to guarantee we land at the very bottom of the container.
-    let attempts = 0;
-    while (attempts < 5) {
-      $virtualizer.scrollToIndex(lastIndex + 999, { align: "start", behavior });
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      attempts++;
-    }
-
-    requestAnimationFrame(() => { initialScrollReady = true; });
-  }
-
-  async function waitForListLoad() {
+  async function scrollToBottom(behavior: ScrollBehavior = "auto") {
     await tick();
+    if (!containerEl) return;
 
-    return new Promise((resolve) => {
-      const check = () => {
-        const lastIndex = chronologicalMessages?.length - 1;
-        if ($virtualizer.getVirtualItems().length > 0 && lastIndex >= 0) {
-          resolve({});
-        } else {
-          requestAnimationFrame(check);
-        }
-      };
-      check();
+    containerEl.scrollTo({
+      top: containerEl.scrollHeight,
+      behavior,
+    });
+
+    requestAnimationFrame(() => {
+      initialScrollReady = true;
+      updateBottomState();
     });
   }
 
@@ -204,29 +230,36 @@
     selected = selected === actionHashB64 ? undefined : isMobile() ? undefined : actionHashB64;
   }
 
-  function handleClickOutside() { selected = undefined; }
+  function handleClickOutside() {
+    selected = undefined;
+  }
 
   function handlePress(actionHashB64: ActionHashB64) {
-    if (isMobile()) selected = actionHashB64;
+    if (isMobile()) {
+      selected = actionHashB64;
+    }
   }
 
   function shouldShowDaySeparator(currentIndex: number) {
     if (currentIndex === 0) return true;
-    const currentMsg = chronologicalMessages?.[currentIndex]?.[1];
-    const prevMsg = chronologicalMessages?.[currentIndex - 1]?.[1];
+
+    const currentMsg = chronologicalMessages[currentIndex]?.[1];
+    const prevMsg = chronologicalMessages[currentIndex - 1]?.[1];
+
     if (!currentMsg || !prevMsg) return true;
-    return !isSameDay(
-      new Date(currentMsg.timestamp / 1000),
-      new Date(prevMsg.timestamp / 1000),
-    );
+
+    return !isSameDay(new Date(currentMsg.timestamp / 1000), new Date(prevMsg.timestamp / 1000));
   }
 
   function shouldShowAuthor(currentIndex: number) {
     if (currentIndex === 0) return true;
-    const currentMsg = chronologicalMessages[currentIndex][1];
-    const prevMsg = chronologicalMessages[currentIndex - 1][1];
+
+    const currentMsg = chronologicalMessages[currentIndex]?.[1];
+    const prevMsg = chronologicalMessages[currentIndex - 1]?.[1];
+
     if (!currentMsg || !prevMsg) return true;
     if (prevMsg.message.message_type === MessageType.System) return true;
+
     return (
       currentMsg.authorAgentPubKeyB64 !== prevMsg.authorAgentPubKeyB64 ||
       !isWithinFiveMinutes(
@@ -247,58 +280,47 @@
   <ConversationHeader {cellIdB64} />
   <div class="flex h-4 items-center justify-center"></div>
 
-  <!-- Loading indicator when fetching older messages -->
   {#if loadingTop}
     <div class="flex h-12 items-center justify-center">
       <div class="h-6 w-6 animate-spin rounded-full border-2 border-primary-500 border-t-transparent"></div>
     </div>
   {/if}
 
-  <!-- Virtualizer content container -->
-  <div style="height: {$virtualizer.getTotalSize()}px; position: relative; width: 100%;">
-    {#each $virtualizer.getVirtualItems() as virtualRow (virtualRow.key)}
-      {@const currentIndex = virtualRow.index}
-      {@const [actionHashB64, messageExtended] = chronologicalMessages[currentIndex]}
-      <div
-        class="absolute left-0 top-0 w-full"
-        style="transform: translateY({virtualRow.start}px);"
-        data-index={virtualRow.index}
-        use:measure
-      >
-        <div class="flex flex-shrink-0 flex-col">
-          {#if shouldShowDaySeparator(currentIndex)}
-            <div class="text-secondary-400 dark:text-secondary-300 my-4 px-4 text-center text-xs">
-              {new Date(messageExtended.timestamp / 1000).toLocaleDateString("en-US", {
-                weekday: "long",
-                month: "long",
-                day: "numeric",
-              })}
-            </div>
-          {/if}
+  {#each chronologicalMessages as [actionHashB64, messageExtended], currentIndex (actionHashB64)}
+    <div use:registerRow={actionHashB64} class="w-full">
+      <div class="flex flex-shrink-0 flex-col">
+        {#if shouldShowDaySeparator(currentIndex)}
+          <div class="text-secondary-400 dark:text-secondary-300 my-4 px-4 text-center text-xs">
+            {new Date(messageExtended.timestamp / 1000).toLocaleDateString("en-US", {
+              weekday: "long",
+              month: "long",
+              day: "numeric",
+            })}
+          </div>
+        {/if}
 
-          {#if messageExtended.message.message_type === MessageType.System}
-            <NoticeMessage {cellIdB64} message={messageExtended} />
-          {:else}
-            <div class="mt-3 px-4">
-              <BaseMessage
-                {cellIdB64}
-                message={messageExtended}
-                isSelected={selected === actionHashB64}
-                showAuthor={shouldShowAuthor(currentIndex)}
-                {actionHashB64}
-                on:press={() => handlePress(actionHashB64)}
-                on:click={(e) => handleClick(e, actionHashB64)}
-                on:clickoutside={handleClickOutside}
-                on:delete
-              />
-            </div>
-          {/if}
+        {#if messageExtended.message.message_type === MessageType.System}
+          <NoticeMessage {cellIdB64} message={messageExtended} />
+        {:else}
+          <div class="mt-3 px-4">
+            <BaseMessage
+              {cellIdB64}
+              message={messageExtended}
+              isSelected={selected === actionHashB64}
+              showAuthor={shouldShowAuthor(currentIndex)}
+              {actionHashB64}
+              on:press={() => handlePress(actionHashB64)}
+              on:click={(e) => handleClick(e, actionHashB64)}
+              on:clickoutside={handleClickOutside}
+              on:delete
+            />
+          </div>
+        {/if}
 
-          {#if currentIndex === chronologicalMessages?.length - 1}
-            <div class="flex h-4 items-center justify-center"></div>
-          {/if}
-        </div>
+        {#if currentIndex === chronologicalMessages.length - 1}
+          <div class="flex h-4 items-center justify-center"></div>
+        {/if}
       </div>
-    {/each}
-  </div>
+    </div>
+  {/each}
 </div>

--- a/ui/src/store/ConversationMessageStore.ts
+++ b/ui/src/store/ConversationMessageStore.ts
@@ -1,3 +1,24 @@
+/**
+ * ConversationMessageStore — production-grade rewrite
+ *
+ * Architecture:
+ *   - Canonical internal order is insertion order in a plain JS object
+ *     { [hash]: MessageExtended }.  All sorted output uses timestamp ASC
+ *     via the deriveGenericKeyValueStore listSortBy parameter.
+ *   - Memory is unbounded during normal use; a hard cap of HARD_MEMORY_LIMIT
+ *     (500) evicts oldest entries only during scroll-up prepend.
+ *   - Three-state pagination cursor:
+ *       oldestMemoryTimestamp  – cursor for the next DB page query
+ *       dbExhausted            – DB has no rows older than the cursor
+ *       networkExhausted       – Holochain returned 0 hashes for older buckets
+ *   - Signal-first dedup: existing in-memory entries always win on merge.
+ *   - loadMoreMessages is the only path that prepends older messages.
+ *     It never calls _initLoadFromDB (which is init-only).
+ *   - _fetchAndStoreTooDB stores to DB only; it never touches in-memory state.
+ *   - Polling (_loadFromBucketPipeline) hydrates memory from the newest DB
+ *     records after storing, using signal-first merge.
+ */
+
 import {
   type CellIdB64,
   type LocalFile,
@@ -16,10 +37,9 @@ import {
   encodeHashToBase64,
   type ActionHashB64,
   type CellId,
-  type HoloHash,
-  type Record,
+  type Record as HolochainRecord,
 } from "@holochain/client";
-import { difference, flatten, range, sortBy, sum } from "lodash-es";
+import { flatten, range, sum } from "lodash-es";
 import type { ConversationStore } from "./ConversationStore";
 import {
   createGenericKeyKeyValueStore,
@@ -37,12 +57,32 @@ import { TARGET_MESSAGES_COUNT, MESSAGES_PER_PAGE } from "$config";
 import type { FileStore } from "./FileStore";
 import { messageDB } from "./db/MessageDatabase";
 
-// Interface for pagination state
+// ── Pagination cursor ─────────────────────────────────────────────────────────
+//
+// oldestMemoryTimestamp
+//   Timestamp of the oldest message currently held in the in-memory store.
+//   Used as the exclusive upper-bound for the next getOlderMessages() DB call.
+//   Recomputed after every operation that could change the oldest end of memory.
+//
+// dbExhausted
+//   Set true when the local DB returns 0 rows older than oldestMemoryTimestamp.
+//   Reset to false after a network backfill writes new messages into the DB.
+//
+// networkExhausted
+//   Set true when Holochain returns 0 action-hashes for all queried buckets
+//   before the cursor bucket.  Prevents infinite retries at history start.
+// ─────────────────────────────────────────────────────────────────────────────
 interface PaginationState {
-  loadedPages: number;
-  totalMessages: number;
-  oldestLoadedTimestamp?: number;
+  oldestMemoryTimestamp: number | undefined;
+  dbExhausted: boolean;
+  networkExhausted: boolean;
 }
+
+// Only evict old messages during scroll-up prepend, and only if memory
+// exceeds this generous limit. Most conversations never reach it.
+const HARD_MEMORY_LIMIT = 500;
+
+// ── Public store interface ────────────────────────────────────────────────────
 
 export interface ConversationMessageStore extends GenericKeyKeyValueStore<MessageExtended> {
   initialize: () => Promise<void>;
@@ -63,7 +103,7 @@ export interface ConversationMessageStore extends GenericKeyKeyValueStore<Messag
   loadMoreMessages: (key1: CellIdB64) => Promise<number>;
   sendMessage: (key1: CellIdB64, content: string, files: LocalFile[]) => Promise<void>;
   sendJoinNotice: (key1: CellIdB64) => Promise<void>;
-  deleteMessage: (key1: CellIdB64, messageContent: string) => Promise<void>;
+  deleteMessage: (key1: CellIdB64, actionHashB64: ActionHashB64) => Promise<void>;
   handleMessageSignalReceived: (key1: CellIdB64, signal: MessageSignal) => Promise<void>;
   handleMessageDeletedSignalReceived: (
     key1: CellIdB64,
@@ -72,385 +112,637 @@ export interface ConversationMessageStore extends GenericKeyKeyValueStore<Messag
   debugGetAllMessages: (key1: CellIdB64) => Promise<MessageRecord[]>;
 }
 
+// ── Factory ───────────────────────────────────────────────────────────────────
+
 export function createConversationMessageStore(
   client: RelayClient,
   conversationStore: ConversationStore,
   mergedProfileContactInviteStore: MergedProfileContactInviteStore,
   fileStore: FileStore,
 ): ConversationMessageStore {
-  function _cid(cellIdB64: CellIdB64) {
-    return cellIdB64.slice(0, 10);
+
+  function _cid(id: CellIdB64): string { return id.slice(0, 10); }
+
+  function _log(stage: string, details?: { [key: string]: unknown }): void {
+    if (details) console.log(`[MessageFlow] ${stage}`, details);
+    else console.log(`[MessageFlow] ${stage}`);
   }
 
-  function _log(stage: string, details?: { [key: string]: unknown }) {
-    if (details) {
-      console.log(`[MessageFlow] ${stage}`, details);
-    } else {
-      console.log(`[MessageFlow] ${stage}`);
-    }
-  }
-
-  // In-memory store holds only active messages (limited by pagination)
+  // ── Internal raw store: { [cellIdB64]: { [hash]: MessageExtended } } ────────
   const messages = createGenericKeyKeyValueStore<MessageExtended>();
 
-  // Track pagination state for each conversation
+  // ── Per-conversation pagination state ─────────────────────────────────────
   const paginationState = writable<{ [cellIdB64: CellIdB64]: PaginationState }>({});
 
-  // Filter out messages by agents who do not have a Contact nor Profile
-  // Don't filter if profiles haven't loaded yet (prevents race condition)
+  // ── Filtered public subscribe ──────────────────────────────────────────────
+  // Hides messages from agents with no known profile/contact unless profiles
+  // haven't loaded yet (prevents a race condition on first open).
   const { subscribe } = derived(
     [messages, mergedProfileContactInviteStore],
     ([$messages, $mergedProfileContactInviteStore]) => {
       const filteredMessages = Object.fromEntries(
         $messages.list.map(([cellIdB64, messagesData]) => {
-          const messagesArray = Object.entries(messagesData);
-
-          // Check if profiles have loaded for this cell
-          const profilesLoadedForCell =
+          const profilesLoaded =
             $mergedProfileContactInviteStore.data[cellIdB64] !== undefined;
 
-          // If profiles haven't loaded yet, show all messages (prevent race condition)
-          // Once profiles load, filter to only show messages from known authors
-          const filtered = messagesArray.filter(([actionHash, messageExtended]) => {
-            // If profiles not loaded yet, don't filter anything out
-            if (!profilesLoadedForCell) {
-              return true;
-            }
-
-            // Always show system messages
-            if (messageExtended.message.message_type === MessageType.System) {
-              return true;
-            }
-
-            // Profiles are loaded, so only show messages from known authors
-            const hasAuthor =
-              $mergedProfileContactInviteStore.data[cellIdB64][
-                messageExtended.authorAgentPubKeyB64
-              ] !== undefined;
-
-            return hasAuthor;
+          const filtered = Object.entries(messagesData).filter(([, msg]) => {
+            if (!profilesLoaded) return true;
+            if (msg.message.message_type === MessageType.System) return true;
+            return (
+              $mergedProfileContactInviteStore.data[cellIdB64][msg.authorAgentPubKeyB64] !==
+              undefined
+            );
           });
 
           return [cellIdB64, Object.fromEntries(filtered)];
         }),
       );
 
-      const result = {
+      return {
         data: filteredMessages,
         list: Object.entries(filteredMessages),
         count: Object.keys(filteredMessages).length,
       };
-
-      return result;
     },
   );
 
-  async function initialize() {
+  // ═══════════════════════════════════════════════════════════════════════════
+  // INITIALIZE
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  async function initialize(): Promise<void> {
     _log("initialize:start");
     const cellInfos = await client.getRelayClonedCellInfos();
-    // Log all Cell IDs for debugging
-    cellInfos.forEach((cellInfo, index) => {
-      const cellIdB64 = encodeCellIdToBase64(cellInfo.cell_id);
-    });
 
-    // Initialize empty messages for each conversation
-    const messagesData = Object.fromEntries(
-      cellInfos.map((cellInfo) => [encodeCellIdToBase64(cellInfo.cell_id), {}]),
+    // Seed empty maps for every known conversation cell
+    messages.set(
+      Object.fromEntries(cellInfos.map((ci) => [encodeCellIdToBase64(ci.cell_id), {}])),
     );
-    messages.set(messagesData);
-
-    // Initialize pagination state
-    const initialPaginationState = Object.fromEntries(
-      cellInfos.map((cellInfo) => [
-        encodeCellIdToBase64(cellInfo.cell_id),
-        { loadedPages: 0, totalMessages: 0 },
-      ]),
+    paginationState.set(
+      Object.fromEntries(
+        cellInfos.map((ci) => [
+          encodeCellIdToBase64(ci.cell_id),
+          { oldestMemoryTimestamp: undefined, dbExhausted: false, networkExhausted: false },
+        ]),
+      ),
     );
-    paginationState.set(initialPaginationState);
 
-    // Load initial messages from IndexedDB for each conversation
     const results = await Promise.allSettled(
       cellInfos.map(async (cellInfo) => {
         const cellIdB64 = encodeCellIdToBase64(cellInfo.cell_id);
+        _log("initialize:cell:start", { cell: _cid(cellIdB64) });
 
-        _log("initialize:conversation:start", { cell: _cid(cellIdB64) });
+        // 1. Load most-recent page from local DB (signal-first merge)
+        await _initLoadFromDB(cellIdB64);
 
-        await _loadMessagesFromDB(cellIdB64, 1); // Load first page
-
-        // If no messages in DB, try to fetch from network
-        const currentState = get(paginationState)[cellIdB64];
-
-        if (currentState.totalMessages === 0) {
-          _log("initialize:conversation:db-empty -> backfill-current-buckets", {
-            cell: _cid(cellIdB64),
-          });
-          // when first initializing go local
+        // 2. If DB was empty, bootstrap from Holochain (local-first for speed)
+        const memCount = Object.keys(get(messages).data[cellIdB64] || {}).length;
+        if (memCount === 0) {
+          _log("initialize:cell:db-empty→network-bootstrap", { cell: _cid(cellIdB64) });
           await loadMessagesInCurrentBucketTargetCount(
-            true,
-            cellIdB64,
-            TARGET_MESSAGES_COUNT,
-            10,
-            50,
+            true, cellIdB64, TARGET_MESSAGES_COUNT, 10, 50,
           );
         }
 
-        const finalState = get(paginationState)[cellIdB64];
-        _log("initialize:conversation:done", {
+        _log("initialize:cell:done", {
           cell: _cid(cellIdB64),
-          loadedPages: finalState?.loadedPages,
-          totalMessages: finalState?.totalMessages,
+          memCount: Object.keys(get(messages).data[cellIdB64] || {}).length,
+          state: get(paginationState)[cellIdB64],
         });
       }),
     );
 
-    // Log any errors
-    results.forEach((result, index) => {
-      if (result.status === "rejected") {
-        console.error(`Failed to load messages for conversation ${index}:`, result.reason);
-      }
+    results.forEach((r, i) => {
+      if (r.status === "rejected")
+        console.error(`[init] cell ${i} failed:`, r.reason);
     });
 
-    _log("initialize:complete", { conversations: cellInfos.length });
+    _log("initialize:complete", { cells: cellInfos.length });
   }
 
+  // ═══════════════════════════════════════════════════════════════════════════
+  // DB → MEMORY  (init only)
+  // ═══════════════════════════════════════════════════════════════════════════
+
   /**
-   * Load messages from IndexedDB into memory store with memory management
-   * Now merges with existing in-memory messages instead of overwriting
+   * Load the most-recent MESSAGES_PER_PAGE messages from IndexedDB into memory.
+   * Used ONLY during initialization; never called from loadMoreMessages.
+   *
+   * Signal-first: if a message is already in memory (e.g., arrived via signal
+   * before init finished) the in-memory copy wins — DB data is never applied
+   * on top of a live entry.
    */
-  async function _loadMessagesFromDB(cellIdB64: CellIdB64, pagesToLoad: number): Promise<void> {
+  async function _initLoadFromDB(cellIdB64: CellIdB64): Promise<void> {
     try {
-      const limit = pagesToLoad * MESSAGES_PER_PAGE;
-      _log("db:load:start", { cell: _cid(cellIdB64), pagesToLoad, limit });
+      await messageDB.clearCacheOnAgentChange(cellIdB64);
+      const dbMessages = await messageDB.getMessages(cellIdB64, MESSAGES_PER_PAGE);
+      _log("db:init-load", { cell: _cid(cellIdB64), count: dbMessages.length });
+      if (dbMessages.length === 0) return;
 
-      // Check if agent changed and clear cache if needed
-      const cacheCleared = await messageDB.clearCacheOnAgentChange(cellIdB64);
+      // Signal-first merge
+      messages.update((m) => {
+        const existing = m[cellIdB64] || {};
+        const merged = { ...existing };
+        for (const [hash, msg] of dbMessages) {
+          if (!(hash in merged)) merged[hash] = msg;
+        }
+        return { ...m, [cellIdB64]: merged };
+      });
 
-      const dbMessages = await messageDB.getMessages(cellIdB64, limit);
-      _log("db:load:result", { cell: _cid(cellIdB64), count: dbMessages.length });
-
-      if (dbMessages.length > 0) {
-        // Sort messages by timestamp (newest to oldest) for natural chat order
-        const sortedMessages = dbMessages.sort(([, a], [, b]) => b.timestamp - a.timestamp);
-
-        // Apply memory management: keep only the most recent messages within limit based on loaded pages
-        const maxMessagesInMemory = pagesToLoad * MESSAGES_PER_PAGE;
-        const messagesToKeep = sortedMessages.slice(0, maxMessagesInMemory); // Keep from beginning (newest)
-        const messageData = Object.fromEntries(messagesToKeep);
-
-        // Merge with existing messages instead of overwriting
-        // This prevents race condition where messages arriving via signal get lost
-        messages.update((m) => {
-          const existing = m[cellIdB64] || {};
-          const merged = { ...existing, ...messageData };
-
-          return {
-            ...m,
-            [cellIdB64]: merged,
-          };
-        });
-        // Update pagination state
-        paginationState.update((state) => ({
-          ...state,
-          [cellIdB64]: {
-            ...state[cellIdB64],
-            loadedPages: pagesToLoad,
-            totalMessages: Object.keys(messagesToKeep).length,
-            oldestLoadedTimestamp: messagesToKeep[messagesToKeep.length - 1]?.[1].timestamp, // Last (oldest) message in memory
-          },
-        }));
-        _log("db:load:memory-updated", {
-          cell: _cid(cellIdB64),
-          loadedPages: pagesToLoad,
-          memoryCount: messagesToKeep.length,
-        });
-      } else {
-        _log("db:load:empty", { cell: _cid(cellIdB64) });
-      }
-    } catch (error) {
-      console.error(" Error loading messages from DB:", error);
+      _refreshOldestCursor(cellIdB64);
+    } catch (err) {
+      console.error("[_initLoadFromDB] failed:", err);
     }
   }
 
+  // ═══════════════════════════════════════════════════════════════════════════
+  // SCROLL-UP PAGINATION
+  // ═══════════════════════════════════════════════════════════════════════════
+
   /**
-   * Load more messages (next page) for infinite scroll
+   * Load the next page of older messages for infinite-scroll.
+   *
+   * Strategy:
+   *   1. Query local DB for messages older than oldestMemoryTimestamp.
+   *   2. If DB is exhausted, run a network backfill then re-query DB.
+   *   3. Merge results into memory (signal-first, no trim on the newest end).
+   *
+   * Returns the number of messages actually new to the in-memory store.
    */
   async function loadMoreMessages(cellIdB64: CellIdB64): Promise<number> {
-    const currentState = get(paginationState)[cellIdB64];
-    if (!currentState?.oldestLoadedTimestamp) {
-      _log("scroll-up:skip:no-oldest-timestamp", { cell: _cid(cellIdB64) });
+    const state = get(paginationState)[cellIdB64];
+    if (!state) return 0;
+
+    const cursor = state.oldestMemoryTimestamp;
+    if (cursor === undefined) {
+      _log("scroll-up:skip:no-cursor", { cell: _cid(cellIdB64) });
       return 0;
     }
 
-    _log("scroll-up:start", {
-      cell: _cid(cellIdB64),
-      oldestLoadedTimestamp: currentState.oldestLoadedTimestamp,
-      loadedPages: currentState.loadedPages,
-    });
+    if (state.networkExhausted) {
+      _log("scroll-up:skip:network-exhausted", { cell: _cid(cellIdB64) });
+      return 0;
+    }
 
-    try {
-      // First, try to load from IndexedDB
-      let olderMessages = await messageDB.getOlderMessages(
-        cellIdB64,
-        currentState.oldestLoadedTimestamp,
-        MESSAGES_PER_PAGE,
-      );
+    _log("scroll-up:start", { cell: _cid(cellIdB64), cursor, ...state });
 
-      let loadedCount = 0;
+    // ── 1. Local DB ────────────────────────────────────────────────────────
+    if (!state.dbExhausted) {
+      const olderMsgs = await messageDB.getOlderMessages(cellIdB64, cursor, MESSAGES_PER_PAGE);
+      _log("scroll-up:db-result", { cell: _cid(cellIdB64), count: olderMsgs.length });
 
-      _log("scroll-up:db-check", { cell: _cid(cellIdB64), olderDbCount: olderMessages.length });
-
-      if (olderMessages.length > 0) {
-        _appendOlderMessagesToMemory(cellIdB64, olderMessages);
-        loadedCount = olderMessages.length;
-        _log("scroll-up:served-from-db", { cell: _cid(cellIdB64), loadedCount });
+      if (olderMsgs.length > 0) {
+        const added = _mergeOlderIntoMemory(cellIdB64, olderMsgs);
+        _log("scroll-up:served-from-db", { cell: _cid(cellIdB64), added });
+        return added;
       }
 
-      // If local DB has no older rows, backfill DB using the standard
-      // bucket -> hashes -> missing entries pipeline, then try local DB again.
-      if (olderMessages.length === 0) {
-        _log("scroll-up:db-empty -> pipeline-backfill", { cell: _cid(cellIdB64) });
+      // DB has nothing older than the cursor — mark exhausted, try network.
+      _setPaginationPartial(cellIdB64, { dbExhausted: true });
+    }
 
-        try {
-          const backfilledCount = await _backfillOlderMessagesToDB(cellIdB64);
-          _log("scroll-up:pipeline-backfill:result", {
-            cell: _cid(cellIdB64),
-            backfilledCount,
-          });
+    // ── 2. Network backfill ────────────────────────────────────────────────
+    _log("scroll-up:network-backfill-start", { cell: _cid(cellIdB64), cursor });
+    const { newlyStored, noMoreOnNetwork } = await _backfillOlderMessagesToDB(
+      cellIdB64,
+      cursor,
+    );
+    _log("scroll-up:network-backfill-result", {
+      cell: _cid(cellIdB64),
+      newlyStored,
+      noMoreOnNetwork,
+    });
 
-          if (backfilledCount > 0) {
-            const stateAfterBackfill = get(paginationState)[cellIdB64];
-            if (!stateAfterBackfill?.oldestLoadedTimestamp) {
-              return loadedCount;
-            }
-            olderMessages = await messageDB.getOlderMessages(
-              cellIdB64,
-              stateAfterBackfill.oldestLoadedTimestamp,
-              MESSAGES_PER_PAGE,
-            );
-            _log("scroll-up:db-retry-after-backfill", {
-              cell: _cid(cellIdB64),
-              olderDbCount: olderMessages.length,
-            });
+    if (noMoreOnNetwork) {
+      _setPaginationPartial(cellIdB64, { networkExhausted: true });
+      return 0;
+    }
 
-            if (olderMessages.length > 0) {
-              _appendOlderMessagesToMemory(cellIdB64, olderMessages);
-              loadedCount = olderMessages.length;
-              _log("scroll-up:served-after-backfill", {
-                cell: _cid(cellIdB64),
-                backfilledCount,
-                loadedCount,
-              });
-            }
-          } else {
-            _log("scroll-up:backfill-no-data", { cell: _cid(cellIdB64) });
-          }
-        } catch (error) {
-          console.error(` [Pipeline Backfill] FAILED:`, error);
-          loadedCount = 0;
+    // Re-query DB with the same cursor. Works whether newlyStored > 0
+    // (fresh data) or == 0 (all hashes already in DB but not in memory).
+    const olderMsgs = await messageDB.getOlderMessages(cellIdB64, cursor, MESSAGES_PER_PAGE);
+    _log("scroll-up:db-retry-after-backfill", {
+      cell: _cid(cellIdB64),
+      count: olderMsgs.length,
+    });
+
+    if (olderMsgs.length > 0) {
+      _setPaginationPartial(cellIdB64, { dbExhausted: false });
+      const added = _mergeOlderIntoMemory(cellIdB64, olderMsgs);
+      _log("scroll-up:served-after-backfill", { cell: _cid(cellIdB64), added });
+      return added;
+    }
+
+    // Backfill ran, DB still returns 0. Edge case: all hashes already in DB
+    // but their timestamps are >= cursor (clock-skew). Do not mark network
+    // exhausted — caller can retry; we just can't serve a page right now.
+    _log("scroll-up:done:no-results-after-backfill", { cell: _cid(cellIdB64) });
+    return 0;
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // MEMORY HELPERS
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Merge a batch of (older) messages into the in-memory store.
+   * Existing entries win (signal-first dedup).
+   * Refreshes the oldest-memory cursor after merging.
+   * Applies HARD_MEMORY_LIMIT eviction (oldest end) if needed.
+   *
+   * Returns the number of entries that were genuinely new to memory.
+   */
+  function _mergeOlderIntoMemory(
+    cellIdB64: CellIdB64,
+    batch: [ActionHashB64, MessageExtended][],
+  ): number {
+    if (batch.length === 0) return 0;
+
+    let addedCount = 0;
+    messages.update((m) => {
+      const existing = m[cellIdB64] || {};
+      const merged = { ...existing };
+      for (const [hash, msg] of batch) {
+        if (!(hash in merged)) {
+          merged[hash] = msg;
+          addedCount++;
         }
       }
-
-      _log("scroll-up:done", { cell: _cid(cellIdB64), loadedCount });
-
-      return loadedCount;
-    } catch (error) {
-      console.error("Error loading more messages:", error);
-      return 0;
-    }
-  }
-
-  function _appendOlderMessagesToMemory(
-    cellIdB64: CellIdB64,
-    olderMessages: [ActionHashB64, MessageExtended][],
-  ) {
-    const currentState = get(paginationState)[cellIdB64] || { loadedPages: 0, totalMessages: 0 };
-
-    // Get current messages and sort them by timestamp (newest to oldest) for natural chat order
-    const currentMessages = get(messages).data[cellIdB64] || {};
-    const currentMessagesList = Object.entries(currentMessages).sort(([, a], [, b]) => b.timestamp - a.timestamp);
-    _log("memory:append-older:start", {
-      cell: _cid(cellIdB64),
-      currentMemoryCount: currentMessagesList.length,
-      olderIncomingCount: olderMessages.length,
+      return { ...m, [cellIdB64]: merged };
     });
 
-    // Combine older messages with current ones - older messages go at the end (bottom)
-    const allMessages = [...currentMessagesList, ...olderMessages];
+    // Refresh cursor; then apply the hard cap (evicts oldest if over limit).
+    _refreshOldestCursor(cellIdB64);
+    _applyHardMemoryCap(cellIdB64);
 
-    // Calculate new loaded pages count
-    const newLoadedPages = currentState.loadedPages + 1;
-    const maxMessagesInMemory = newLoadedPages * MESSAGES_PER_PAGE;
+    return addedCount;
+  }
 
-    // Apply memory management: keep only the most recent messages within limit
-    const messagesToKeep = allMessages.slice(0, maxMessagesInMemory);
-    const updatedMessages = Object.fromEntries(messagesToKeep);
-    messages.update((m) => ({
-      ...m,
-      [cellIdB64]: updatedMessages,
-    }));
+  /**
+   * Insert a single newest-end message into memory.
+   * Does NOT update oldestMemoryTimestamp unless memory was empty.
+   * Does NOT trim — new signals and sent messages must always stay visible.
+   */
+  function _insertNewestIntoMemory(
+    cellIdB64: CellIdB64,
+    hash: ActionHashB64,
+    msg: MessageExtended,
+  ): void {
+    messages.update((m) => {
+      const existing = m[cellIdB64] || {};
+      if (hash in existing) return m; // already present
+      return { ...m, [cellIdB64]: { ...existing, [hash]: msg } };
+    });
 
-    paginationState.update((state) => ({
-      ...state,
+    // If this is the very first message in memory, initialise the cursor.
+    paginationState.update((s) => {
+      const cur = s[cellIdB64] ?? {
+        oldestMemoryTimestamp: undefined,
+        dbExhausted: false,
+        networkExhausted: false,
+      };
+      if (cur.oldestMemoryTimestamp === undefined) {
+        return { ...s, [cellIdB64]: { ...cur, oldestMemoryTimestamp: msg.timestamp } };
+      }
+      return s;
+    });
+  }
+
+  /**
+   * Recompute and persist the minimum timestamp across all in-memory messages.
+   * Must be called after any operation that may change the oldest end of memory.
+   */
+  function _refreshOldestCursor(cellIdB64: CellIdB64): void {
+    const mem = get(messages).data[cellIdB64] || {};
+    const vals = Object.values(mem);
+    if (vals.length === 0) {
+      _setPaginationPartial(cellIdB64, { oldestMemoryTimestamp: undefined });
+      return;
+    }
+    const oldest = Math.min(...vals.map((m) => m.timestamp));
+    _setPaginationPartial(cellIdB64, { oldestMemoryTimestamp: oldest });
+  }
+
+  /**
+   * Evict the oldest messages when memory exceeds HARD_MEMORY_LIMIT.
+   * Called only during scroll-up prepend; never during signal receipt.
+   * Keeps the HARD_MEMORY_LIMIT most-recent messages.
+   */
+  function _applyHardMemoryCap(cellIdB64: CellIdB64): void {
+    const mem = get(messages).data[cellIdB64] || {};
+    const entries = Object.entries(mem);
+    if (entries.length <= HARD_MEMORY_LIMIT) return;
+
+    // Sort newest-first, keep the head.
+    const sorted = [...entries].sort(([, a], [, b]) => b.timestamp - a.timestamp);
+    const kept = sorted.slice(0, HARD_MEMORY_LIMIT);
+
+    messages.update((m) => ({ ...m, [cellIdB64]: Object.fromEntries(kept) }));
+    _refreshOldestCursor(cellIdB64);
+
+    _log("memory:hard-cap-applied", {
+      cell: _cid(cellIdB64),
+      evicted: entries.length - HARD_MEMORY_LIMIT,
+    });
+  }
+
+  function _setPaginationPartial(
+    cellIdB64: CellIdB64,
+    patch: Partial<PaginationState>,
+  ): void {
+    paginationState.update((s) => ({
+      ...s,
       [cellIdB64]: {
-        ...state[cellIdB64],
-        loadedPages: newLoadedPages,
-        totalMessages: messagesToKeep.length,
-        oldestLoadedTimestamp: messagesToKeep[messagesToKeep.length - 1]?.[1].timestamp,
+        ...(s[cellIdB64] ?? {
+          oldestMemoryTimestamp: undefined,
+          dbExhausted: false,
+          networkExhausted: false,
+        }),
+        ...patch,
       },
     }));
-
-    _log("memory:append-older:done", {
-      cell: _cid(cellIdB64),
-      newLoadedPages,
-      keptInMemory: messagesToKeep.length,
-    });
   }
 
-  async function _backfillOlderMessagesToDB(cellIdB64: CellIdB64): Promise<number> {
-    const currentMessages = get(messages).data[cellIdB64] || {};
-    const messagesList = Object.entries(currentMessages).sort(([, a], [, b]) => a.timestamp - b.timestamp);
-    const oldestMessage = messagesList[0]?.[1];
+  // ═══════════════════════════════════════════════════════════════════════════
+  // NETWORK BACKFILL  (scroll-up)
+  // ═══════════════════════════════════════════════════════════════════════════
 
-    if (!oldestMessage) return 0;
+  /**
+   * Query Holochain for message hashes in buckets before cursorTimestamp,
+   * download entries that are missing from IndexedDB, store them.
+   * Does NOT update the in-memory store (caller does that via a DB query).
+   *
+   * Returns:
+   *   newlyStored    – count of messages newly written to IndexedDB
+   *   noMoreOnNetwork – true when Holochain returned 0 hashes for all queried buckets
+   */
+  async function _backfillOlderMessagesToDB(
+    cellIdB64: CellIdB64,
+    cursorTimestamp: number,
+  ): Promise<{ newlyStored: number; noMoreOnNetwork: boolean }> {
+    const oldestBucket = conversationStore.getBucket(cellIdB64, cursorTimestamp);
+    if (oldestBucket <= 0) {
+      return { newlyStored: 0, noMoreOnNetwork: true };
+    }
 
-    const oldestBucket = oldestMessage.message.bucket;
-    if (oldestBucket <= 0) return 0;
+    _log("backfill:start", { cell: _cid(cellIdB64), startBucket: oldestBucket - 1 });
 
-    // Use the same underlying bucket/hash/entry pipeline used elsewhere.
-    _log("pipeline-backfill:start", {
-      cell: _cid(cellIdB64),
-      fromBucket: oldestBucket - 1,
-      oldestBucket,
-    });
-
-    return _loadMessagesFromBucketTargetCount(
-      true,
+    // Fetch bucket hashes from Holochain (local DHT first to avoid slow network calls)
+    const bucketsToFetch = await _fetchBucketsTargetCount(
       cellIdB64,
       oldestBucket - 1,
+      true,
       TARGET_MESSAGES_COUNT,
       3,
       3,
     );
+
+    const allHashes = flatten(bucketsToFetch.map((b) => b.actionHashB64s));
+
+    if (allHashes.length === 0) {
+      _log("backfill:no-hashes-on-network", { cell: _cid(cellIdB64) });
+      return { newlyStored: 0, noMoreOnNetwork: true };
+    }
+
+    const missingHashes = await _filterMissingHashesFromDB(allHashes);
+    _log("backfill:missing-from-db", {
+      cell: _cid(cellIdB64),
+      total: allHashes.length,
+      missing: missingHashes.length,
+    });
+
+    if (missingHashes.length === 0) {
+      // All hashes already in DB. Not network-exhausted — DB just has everything.
+      // The edge case (all in DB but wrong timestamps) is handled by the caller.
+      return { newlyStored: 0, noMoreOnNetwork: false };
+    }
+
+    const newlyStored = await _fetchAndStoreToDB(cellIdB64, missingHashes);
+    return { newlyStored, noMoreOnNetwork: false };
   }
 
-  async function sendMessage(key1: CellIdB64, content: string, files: LocalFile[]) {
+  // ═══════════════════════════════════════════════════════════════════════════
+  // POLLING / BUCKET PIPELINE  (current bucket refresh)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /**
+   * Fetch hashes from the current bucket range, download missing entries,
+   * store to DB, then hydrate the newest messages into memory.
+   * Used for initial load and ongoing polling — NOT for scroll-up.
+   */
+  async function loadMessagesInCurrentBucketTargetCount(
+    local: boolean,
+    key1: CellIdB64,
+    targetCount = TARGET_MESSAGES_COUNT,
+    bucketChunkSize = 3,
+    maxBucketsToFetch?: number,
+  ): Promise<number> {
+    const bucket = conversationStore.getBucket(key1, Date.now());
+    return _loadFromBucketPipeline(
+      local, key1, bucket, targetCount, bucketChunkSize, maxBucketsToFetch,
+    );
+  }
+
+  /**
+   * Same as above but starting from the bucket before the oldest in-memory message.
+   */
+  async function loadMessagesInPreviousBucketTargetCount(
+    local: boolean,
+    key1: CellIdB64,
+    targetCount = TARGET_MESSAGES_COUNT,
+    bucketChunkSize = 3,
+    maxBucketsToFetch?: number,
+  ): Promise<number> {
+    const cursor = get(paginationState)[key1]?.oldestMemoryTimestamp;
+    if (!cursor) return 0;
+    const oldestBucket = conversationStore.getBucket(key1, cursor);
+    return _loadFromBucketPipeline(
+      local, key1, oldestBucket - 1, targetCount, bucketChunkSize, maxBucketsToFetch,
+    );
+  }
+
+  /**
+   * Core bucket → hash → entry → DB → memory pipeline.
+   * Stores missing entries to DB, then hydrates the newest MESSAGES_PER_PAGE
+   * into memory using a signal-first merge.
+   */
+  async function _loadFromBucketPipeline(
+    local: boolean,
+    key1: CellIdB64,
+    bucket: number,
+    targetCount: number,
+    bucketChunkSize: number,
+    maxBucketsToFetch?: number,
+  ): Promise<number> {
+    _log("pipeline:start", { cell: _cid(key1), local, bucket, targetCount });
+
+    const bucketsToFetch = await _fetchBucketsTargetCount(
+      key1, bucket, local, targetCount, bucketChunkSize, maxBucketsToFetch,
+    );
+
+    const allHashes = flatten(bucketsToFetch.map((b) => b.actionHashB64s));
+    _log("pipeline:hashes", { cell: _cid(key1), total: allHashes.length });
+
+    const missingHashes = await _filterMissingHashesFromDB(allHashes);
+    _log("pipeline:missing", { cell: _cid(key1), missing: missingHashes.length });
+
+    if (missingHashes.length === 0) {
+      _log("pipeline:no-new-messages", { cell: _cid(key1) });
+      return 0;
+    }
+
+    const stored = await _fetchAndStoreToDB(key1, missingHashes);
+    _log("pipeline:stored", { cell: _cid(key1), stored });
+
+    // Hydrate the newest page into memory so new messages are immediately visible.
+    await _hydrateNewestFromDB(key1);
+
+    return stored;
+  }
+
+  /**
+   * Read the newest MESSAGES_PER_PAGE messages from DB and merge them into
+   * memory using signal-first policy. Updates the oldest cursor.
+   */
+  async function _hydrateNewestFromDB(cellIdB64: CellIdB64): Promise<void> {
+    const dbMessages = await messageDB.getMessages(cellIdB64, MESSAGES_PER_PAGE);
+    if (dbMessages.length === 0) return;
+
+    messages.update((m) => {
+      const existing = m[cellIdB64] || {};
+      const merged = { ...existing };
+      for (const [hash, msg] of dbMessages) {
+        if (!(hash in merged)) merged[hash] = msg;
+      }
+      return { ...m, [cellIdB64]: merged };
+    });
+
+    _refreshOldestCursor(cellIdB64);
+    _log("db:hydrate-newest", {
+      cell: _cid(cellIdB64),
+      dbCount: dbMessages.length,
+      memCount: Object.keys(get(messages).data[cellIdB64] || {}).length,
+    });
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // NETWORK PIPELINE HELPERS
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  async function _fetchBucketsTargetCount(
+    key1: CellIdB64,
+    bucket: number,
+    local: boolean,
+    targetCount: number,
+    bucketChunkSize: number,
+    maxBucketsToFetch?: number,
+  ): Promise<{ bucket: number; actionHashB64s: ActionHashB64[] }[]> {
     const cellId = decodeCellIdFromBase64(key1);
+    let bucketsToFetch: { bucket: number; actionHashB64s: ActionHashB64[] }[] = [];
+
+    while (
+      sum(bucketsToFetch.map(({ actionHashB64s }) => actionHashB64s.length)) <= targetCount &&
+      bucket >= 0 &&
+      (maxBucketsToFetch === undefined || bucketsToFetch.length <= maxBucketsToFetch)
+    ) {
+      const chunk = range(bucket, bucket - bucketChunkSize).filter((b) => b >= 0);
+      _log("pipeline:bucket-scan:chunk", { cell: _cid(key1), chunk, local });
+
+      bucketsToFetch = [
+        ...bucketsToFetch,
+        ...(await Promise.all(
+          chunk.map(async (b) => ({
+            bucket: b,
+            actionHashB64s: (
+              await client.getMessageHashes(cellId, { bucket: b, count: 0 }, local)
+            ).map(encodeHashToBase64),
+          })),
+        )),
+      ];
+      bucket -= 1;
+    }
+
+    // Trim the last bucket if we already exceeded targetCount without it.
+    while (
+      sum(bucketsToFetch.slice(0, -1).map(({ actionHashB64s }) => actionHashB64s.length)) >
+      targetCount
+    ) {
+      bucketsToFetch.pop();
+    }
+
+    return bucketsToFetch;
+  }
+
+  /**
+   * Parallel bulk-filter: return only the hashes not already in IndexedDB.
+   */
+  async function _filterMissingHashesFromDB(
+    actionHashB64s: ActionHashB64[],
+  ): Promise<ActionHashB64[]> {
+    if (actionHashB64s.length === 0) return [];
+    const checks = await Promise.all(
+      actionHashB64s.map(async (h) => ({ h, exists: await messageDB.hasMessage(h) })),
+    );
+    return checks.filter((c) => !c.exists).map((c) => c.h);
+  }
+
+  /**
+   * Fetch entries from Holochain, store them in IndexedDB.
+   * Does NOT update the in-memory store. Returns count of stored entries.
+   */
+  async function _fetchAndStoreToDB(
+    key1: CellIdB64,
+    hashes: ActionHashB64[],
+  ): Promise<number> {
+    if (hashes.length === 0) return 0;
+    _log("fetch-store:start", { cell: _cid(key1), hashes: hashes.length });
+
+    const cellId = decodeCellIdFromBase64(key1);
+    const records = await client.getMessageEntries(
+      cellId,
+      hashes.map(decodeHashFromBase64),
+      false,
+    );
+    _log("fetch-store:records", { cell: _cid(key1), fetched: records.length });
+
+    const settled = await Promise.allSettled(
+      records.map(
+        async (r) =>
+          [
+            encodeHashToBase64(r.original_action),
+            await _makeMessageExtended(cellId, r),
+          ] as [ActionHashB64, MessageExtended],
+      ),
+    );
+
+    const valid = settled.filter((p) => p.status === "fulfilled").map((p) => p.value);
+    if (valid.length === 0) return 0;
+
+    await messageDB.storeMessages(key1, valid);
+    _log("fetch-store:stored", { cell: _cid(key1), count: valid.length });
+    return valid.length;
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // SEND MESSAGE
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  async function sendMessage(key1: CellIdB64, content: string, files: LocalFile[]): Promise<void> {
+    const cellId = decodeCellIdFromBase64(key1);
+
     const messageFiles = await Promise.all(
       files.map(async (file) => {
         const entryHash = await fileStore.upload(key1, file.file);
-
-        const messageFile: MessageFile = {
+        return {
           last_modified: file.file.lastModified,
           name: file.file.name,
           size: file.file.size,
           storage_entry_hash: entryHash,
           file_type: file.file.type,
-        };
-        return messageFile;
+        } as MessageFile;
       }),
     );
 
-    // Get all AgentPubKeys in the conversation.
     const mergedProfileContact = deriveCellMergedProfileContactInviteStore(
       mergedProfileContactInviteStore,
       key1,
@@ -458,11 +750,10 @@ export function createConversationMessageStore(
     );
     const agentPubKeys = get(mergedProfileContact).list.map(([a]) => decodeHashFromBase64(a));
 
-    // Create Message entry
     const record = await client.createMessage(cellId, {
       message: {
         content,
-        bucket: conversationStore.getBucket(key1, new Date().getTime()),
+        bucket: conversationStore.getBucket(key1, Date.now()),
         images: messageFiles,
         message_type: MessageType.User,
       },
@@ -470,7 +761,7 @@ export function createConversationMessageStore(
     });
 
     const message = new EntryRecord<Message>(record).entry;
-    if (message === undefined) throw new Error("Failed to decode Message entry from record");
+    if (!message) throw new Error("Failed to decode Message entry from record");
 
     const messageExtended = await _makeMessageExtended(cellId, {
       message,
@@ -480,61 +771,13 @@ export function createConversationMessageStore(
 
     const actionHashB64 = encodeHashToBase64(record.signed_action.hashed.hash);
 
-    // Store in IndexedDB first
+    // Persist first, then update memory.
     await messageDB.storeMessage(key1, actionHashB64, messageExtended);
-
-    // Update in-memory store (add new message at the end - newest timestamp)
-    messages.update((m) => {
-      const currentMessages = m[key1] || {};
-      const messagesList = Object.entries(currentMessages).sort(
-        ([, a], [, b]) => a.timestamp - b.timestamp, // oldest to newest
-      );
-
-      // Add new message at the end (it has the newest timestamp)
-      const updatedMessages = Object.fromEntries([
-        ...messagesList,
-        [actionHashB64, messageExtended],
-      ]);
-
-      return {
-        ...m,
-        [key1]: updatedMessages,
-      };
-    });
-
-    // Apply memory management after adding new message
-    _applyMemoryManagement(key1);
-
-    // Update pagination state to reflect new message and potentially increase effective loaded pages
-    paginationState.update((state) => {
-      const currentState = state[key1] || { loadedPages: 1, totalMessages: 0 };
-      const newTotalMessages = (currentState.totalMessages || 0) + 1;
-
-      // If we're actively sending messages, consider that the user wants to see more recent content
-      // Increase effective loaded pages if we have more messages than current page limit
-      const currentLimit = currentState.loadedPages * MESSAGES_PER_PAGE;
-      const newLoadedPages =
-        newTotalMessages > currentLimit
-          ? Math.ceil(newTotalMessages / MESSAGES_PER_PAGE)
-          : currentState.loadedPages;
-
-      return {
-        ...state,
-        [key1]: {
-          ...currentState,
-          loadedPages: Math.max(newLoadedPages, currentState.loadedPages),
-          totalMessages: newTotalMessages,
-        },
-      };
-    });
+    _insertNewestIntoMemory(key1, actionHashB64, messageExtended);
   }
 
   async function sendJoinNotice(key1: CellIdB64): Promise<void> {
     const cellId = decodeCellIdFromBase64(key1);
-
-    // We just joined, so the local cache won't have other agents yet.
-    // If this fails, fall back to self, the message still lands on the DHT
-    // and others will see it when they next load messages.
     let agentPubKeys;
     try {
       agentPubKeys = await client.getAgentsWithProfile(cellId);
@@ -542,20 +785,18 @@ export function createConversationMessageStore(
       agentPubKeys = [client.client.myPubKey];
     }
 
-    const message: Message = {
-      content: "",
-      bucket: conversationStore.getBucket(key1, new Date().getTime()),
-      images: [],
-      message_type: MessageType.System,
-    };
-
     const record = await client.createMessage(cellId, {
-      message,
+      message: {
+        content: "",
+        bucket: conversationStore.getBucket(key1, Date.now()),
+        images: [],
+        message_type: MessageType.System,
+      },
       agents: agentPubKeys,
     });
 
     const entryMessage = new EntryRecord<Message>(record).entry;
-    if (entryMessage === undefined) throw new Error("Failed to decode Message entry from record");
+    if (!entryMessage) throw new Error("Failed to decode Message entry from record");
 
     const messageExtended = await _makeMessageExtended(cellId, {
       message: entryMessage,
@@ -564,21 +805,56 @@ export function createConversationMessageStore(
     });
 
     const actionHashB64 = encodeHashToBase64(record.signed_action.hashed.hash);
+    await messageDB.storeMessage(key1, actionHashB64, messageExtended);
+    _insertNewestIntoMemory(key1, actionHashB64, messageExtended);
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // SIGNAL HANDLER
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  async function handleMessageSignalReceived(
+    key1: CellIdB64,
+    signal: MessageSignal,
+  ): Promise<void> {
+    const actionHashB64 = encodeHashToBase64(signal.action.hashed.hash);
+
+    // DB dedup first (cheaper than making the MessageExtended)
+    if (await messageDB.hasMessage(actionHashB64)) {
+      _log("signal:dup-db", { cell: _cid(key1), hash: actionHashB64 });
+      return;
+    }
+    // Memory dedup (fast path for race conditions)
+    if (actionHashB64 in (get(messages).data[key1] || {})) {
+      _log("signal:dup-memory", { cell: _cid(key1), hash: actionHashB64 });
+      return;
+    }
+
+    const messageExtended = await _makeMessageExtended(decodeCellIdFromBase64(key1), {
+      message: signal.message,
+      original_action: signal.action.hashed.hash,
+      signed_action: signal.action,
+    });
 
     await messageDB.storeMessage(key1, actionHashB64, messageExtended);
+    _insertNewestIntoMemory(key1, actionHashB64, messageExtended);
 
-    messages.update((m) => ({
-      ...m,
-      [key1]: {
-        ...(m[key1] || {}),
-        [actionHashB64]: messageExtended,
-      },
-    }));
+    // Notification
+    const mergedProfileContact = deriveCellMergedProfileContactInviteStore(
+      mergedProfileContactInviteStore,
+      key1,
+      encodeHashToBase64(client.client.myPubKey),
+    );
+    const fromProfile = get(mergedProfileContact).data[encodeHashToBase64(signal.from)];
+    _triggerMessageNotification(messageExtended, fromProfile);
   }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // DELETE
+  // ═══════════════════════════════════════════════════════════════════════════
 
   async function deleteMessage(key1: CellIdB64, actionHashB64: ActionHashB64): Promise<void> {
     const cellId = decodeCellIdFromBase64(key1);
-
     const mergedProfileContact = deriveCellMergedProfileContactInviteStore(
       mergedProfileContactInviteStore,
       key1,
@@ -591,486 +867,89 @@ export function createConversationMessageStore(
       agents: agentPubKeys,
     });
 
-    // Remove from IndexedDB
     await messageDB.deleteMessage(actionHashB64);
-
-    // Remove from in-memory store
-    messages.update((m) => {
-      const k = { ...m[key1] };
-      delete k[actionHashB64];
-      return {
-        ...m,
-        [key1]: k,
-      };
-    });
+    _removeFromMemory(key1, actionHashB64);
   }
 
-  async function handleMessageDeletedSignalReceived(key1: CellIdB64, actionHashB64: ActionHashB64) {
-    const currentMessages = get(messages).data[key1];
-    if (currentMessages[actionHashB64] === undefined) {
-      return;
-    }
-
-    // Remove from IndexedDB
+  async function handleMessageDeletedSignalReceived(
+    key1: CellIdB64,
+    actionHashB64: ActionHashB64,
+  ): Promise<void> {
+    if (!(actionHashB64 in (get(messages).data[key1] || {}))) return;
     await messageDB.deleteMessage(actionHashB64);
+    _removeFromMemory(key1, actionHashB64);
+  }
 
-    // Remove from in-memory store
+  function _removeFromMemory(cellIdB64: CellIdB64, actionHashB64: ActionHashB64): void {
     messages.update((m) => {
-      const k = { ...m[key1] };
-      delete k[actionHashB64];
-      return {
-        ...m,
-        [key1]: k,
-      };
+      const copy = { ...(m[cellIdB64] || {}) };
+      delete copy[actionHashB64];
+      return { ...m, [cellIdB64]: copy };
     });
+    // Cursor may have changed if we removed the oldest message.
+    _refreshOldestCursor(cellIdB64);
   }
 
-  async function handleMessageSignalReceived(key1: CellIdB64, signal: MessageSignal) {
-    const actionHashB64 = encodeHashToBase64(signal.action.hashed.hash);
-
-    // Check for duplicates before processing
-    const exists = await messageDB.hasMessage(actionHashB64);
-    if (exists) {
-      console.log(`Message ${actionHashB64} already exists, skipping duplicate`);
-      return; // Skip duplicate
-    }
-
-    // Check if already in memory (double-check for race conditions)
-    const currentMessages = get(messages).data[key1] || {};
-    if (currentMessages[actionHashB64]) {
-      console.log(`Message ${actionHashB64} already in memory, skipping duplicate`);
-      return;
-    }
-
-    // Make MessageExtended
-    const messageExtended = await _makeMessageExtended(decodeCellIdFromBase64(key1), {
-      message: signal.message,
-      original_action: signal.action.hashed.hash,
-      signed_action: signal.action,
-    });
-
-    // Store in IndexedDB first
-    await messageDB.storeMessage(key1, actionHashB64, messageExtended);
-
-    // Add to in-memory store (add new message at the end - newest timestamp)
-    messages.update((m) => {
-      const currentMessages = m[key1] || {};
-      const messagesList = Object.entries(currentMessages).sort(
-        ([, a], [, b]) => a.timestamp - b.timestamp, // oldest to newest
-      );
-
-      // Add new message at the end (it has the newest timestamp)
-      const updatedMessages = Object.fromEntries([
-        ...messagesList,
-        [actionHashB64, messageExtended],
-      ]);
-
-      return {
-        ...m,
-        [key1]: updatedMessages,
-      };
-    });
-
-    // Apply memory management after receiving new message
-    _applyMemoryManagement(key1);
-
-    // Update pagination state to reflect new message and potentially increase effective loaded pages
-    paginationState.update((state) => {
-      const currentState = state[key1] || { loadedPages: 1, totalMessages: 0 };
-      const newTotalMessages = (currentState.totalMessages || 0) + 1;
-
-      // If we're actively receiving messages, consider that the user wants to see more recent content
-      // Increase effective loaded pages if we have more messages than current page limit
-      const currentLimit = currentState.loadedPages * MESSAGES_PER_PAGE;
-      const newLoadedPages =
-        newTotalMessages > currentLimit
-          ? Math.ceil(newTotalMessages / MESSAGES_PER_PAGE)
-          : currentState.loadedPages;
-
-      return {
-        ...state,
-        [key1]: {
-          ...currentState,
-          loadedPages: Math.max(newLoadedPages, currentState.loadedPages),
-          totalMessages: newTotalMessages,
-        },
-      };
-    });
-
-    // Get Profile of Message author
-    const mergedProfileContact = deriveCellMergedProfileContactInviteStore(
-      mergedProfileContactInviteStore,
-      key1,
-      encodeHashToBase64(client.client.myPubKey),
-    );
-    const fromProfile = get(mergedProfileContact).data[encodeHashToBase64(signal.from)];
-
-    // Trigger a system notification
-    _triggerMessageNotification(messageExtended, fromProfile);
-  }
-
-  /**
-   * Load messages, starting at the current bucket and working backwards,
-   * until at least a targetCount have been fetched.
-   */
-  async function loadMessagesInCurrentBucketTargetCount(
-    local: boolean,
-    key1: CellIdB64,
-    targetCount = TARGET_MESSAGES_COUNT,
-    bucketChunkSize: number = 3,
-    maxBucketsToFetch?: number,
-  ): Promise<number> {
-    let bucket = conversationStore.getBucket(key1, new Date().getTime());
-
-    return _loadMessagesFromBucketTargetCount(
-      local,
-      key1,
-      bucket,
-      targetCount,
-      bucketChunkSize,
-      maxBucketsToFetch,
-    );
-  }
-
-  /**
-   * Load messages, starting at the oldest stored message's bucket and working backwards,
-   * until at least a targetCount have been fetched.
-   */
-  async function loadMessagesInPreviousBucketTargetCount(
-    local: boolean,
-    key1: CellIdB64,
-    targetCount = TARGET_MESSAGES_COUNT,
-    bucketChunkSize: number = 3,
-    maxBucketsToFetch?: number,
-  ): Promise<number> {
-    const currentState = get(paginationState)[key1];
-    if (!currentState?.oldestLoadedTimestamp) {
-      return 0;
-    }
-
-    // Find the bucket for the oldest loaded message
-    const oldestBucket = conversationStore.getBucket(key1, currentState.oldestLoadedTimestamp);
-
-    return _loadMessagesFromBucketTargetCount(
-      local,
-      key1,
-      oldestBucket - 1,
-      targetCount,
-      bucketChunkSize,
-      maxBucketsToFetch,
-    );
-  }
-
-  /**
-   * Main function for fetching and loading messages from network
-   */
-  async function _loadMessagesFromBucketTargetCount(
-    local: boolean,
-    key1: CellIdB64,
-    bucket: number,
-    targetCount: number = TARGET_MESSAGES_COUNT,
-    bucketChunkSize: number = 3,
-    maxBucketsToFetch?: number,
-  ): Promise<number> {
-    _log("pipeline:bucket-target:start", {
-      cell: _cid(key1),
-      local,
-      bucket,
-      targetCount,
-      bucketChunkSize,
-      maxBucketsToFetch,
-    });
-
-    // Fetch the list of buckets that contain the target count
-    const bucketsToFetch = await _fetchBucketsTargetCount(
-      key1,
-      bucket,
-      local,
-      targetCount,
-      bucketChunkSize,
-      maxBucketsToFetch,
-    );
-    _log("pipeline:bucket-target:fetched-buckets", {
-      cell: _cid(key1),
-      bucketsFetched: bucketsToFetch.length,
-      totalHashes: sum(bucketsToFetch.map(({ actionHashB64s }) => actionHashB64s.length)),
-    });
-
-    const actionHashB64s = flatten(bucketsToFetch.map(({ actionHashB64s }) => actionHashB64s));
-
-    // Filter only messages we are not storing already (check IndexedDB)
-    const missingActionHashB64s = await _filterMissingMessagesFromDB(key1, actionHashB64s);
-    _log("pipeline:bucket-target:missing-after-db-filter", {
-      cell: _cid(key1),
-      totalHashes: actionHashB64s.length,
-      missingCount: missingActionHashB64s.length,
-    });
-
-    // Fetch and save missing message data
-    const count = await _loadMessages(key1, missingActionHashB64s);
-    _log("pipeline:bucket-target:done", { cell: _cid(key1), loadedCount: count });
-
-    return count;
-  }
-
-  /**
-   * Fetch bucket's ActionHashes, starting at the given bucket and working backwards,
-   * until at least a targetCount of ActionHashes have been received.
-   */
-  async function _fetchBucketsTargetCount(
-    key1: CellIdB64,
-    bucket: number,
-    local: boolean,
-    targetCount: number = TARGET_MESSAGES_COUNT,
-    bucketChunkSize: number = 3,
-    maxBucketsToFetch?: number,
-  ): Promise<{ bucket: number; actionHashB64s: ActionHashB64[] }[]> {
-    const cellId = decodeCellIdFromBase64(key1);
-
-    let bucketsToFetch: { bucket: number; actionHashB64s: ActionHashB64[] }[] = [];
-    while (
-      sum(bucketsToFetch.map(({ actionHashB64s }) => actionHashB64s.length)) <= targetCount &&
-      bucket >= 0 &&
-      (maxBucketsToFetch === undefined || bucketsToFetch.length <= maxBucketsToFetch)
-    ) {
-      const bucketsChunk = range(bucket, bucket - bucketChunkSize).filter((b) => b >= 0);
-      _log("pipeline:bucket-scan:chunk", { cell: _cid(key1), bucketsChunk, local });
-      bucketsToFetch = [
-        ...bucketsToFetch,
-        ...(await Promise.all(
-          bucketsChunk.map(async (b) => ({
-            bucket: b,
-            actionHashB64s: (
-              await client.getMessageHashes(
-                cellId,
-                {
-                  bucket: b,
-                  count: 0,
-                },
-                local,
-              )
-            ).map((a) => encodeHashToBase64(a)),
-          })),
-        )),
-      ];
-      bucket -= 1;
-    }
-
-    while (
-      sum(bucketsToFetch.slice(0, -1).map(({ actionHashB64s }) => actionHashB64s.length)) >
-      targetCount
-    ) {
-      bucketsToFetch.pop();
-    }
-
-    return bucketsToFetch;
-  }
-
-  /**
-   * Determine which messages we are currently missing from IndexedDB
-   */
-  async function _filterMissingMessagesFromDB(
-    key1: CellIdB64,
-    actionHashB64s: ActionHashB64[],
-  ): Promise<ActionHashB64[]> {
-    const missingMessages: ActionHashB64[] = [];
-
-    for (const actionHashB64 of actionHashB64s) {
-      const exists = await messageDB.hasMessage(actionHashB64);
-      if (!exists) {
-        missingMessages.push(actionHashB64);
-      }
-    }
-
-    return missingMessages;
-  }
-
-  async function _loadMessages(key1: CellIdB64, actionHashB64s: ActionHashB64[]): Promise<number> {
-    if (actionHashB64s.length === 0) {
-      _log("pipeline:load-messages:skip-no-missing-hashes", { cell: _cid(key1) });
-      return 0;
-    }
-
-    _log("pipeline:load-messages:start", { cell: _cid(key1), missingHashes: actionHashB64s.length });
-
-    const cellId = decodeCellIdFromBase64(key1);
-
-    // Fetch missing messages from network
-    const messageRecords: Array<MessageRecord> = await client.getMessageEntries(
-      cellId,
-      actionHashB64s.map((a) => decodeHashFromBase64(a)),
-      false,
-    );
-    _log("pipeline:load-messages:fetched-records", {
-      cell: _cid(key1),
-      fetchedRecords: messageRecords.length,
-    });
-
-    // Transform Messages into MessageExtendeds
-    const messageEntries = await Promise.allSettled(
-      messageRecords.map(
-        async (m) =>
-          [encodeHashToBase64(m.original_action), await _makeMessageExtended(cellId, m)] as [
-            ActionHashB64,
-            MessageExtended,
-          ],
-      ),
-    );
-
-    const validMessages = messageEntries
-      .filter((p) => p.status === "fulfilled")
-      .map((p) => p.value);
-
-    if (validMessages.length === 0) {
-      _log("pipeline:load-messages:no-valid-messages", { cell: _cid(key1) });
-      return 0;
-    }
-
-    console.group(" SAVING TO INDEXEDDB");
-    console.log(`Cell ID: ${key1.substring(0, 15)}...`);
-    console.log(`Attempting to save ${validMessages.length} messages to local database.`);
-    console.log("Data payload:", validMessages);
-    console.groupEnd();
-
-    // Store in IndexedDB first
-    await messageDB.storeMessages(key1, validMessages);
-    _log("pipeline:load-messages:stored-to-db", {
-      cell: _cid(key1),
-      storedCount: validMessages.length,
-    });
-
-    // Load appropriate messages into memory store based on current pagination
-    await _loadMessagesFromDB(key1, get(paginationState)[key1]?.loadedPages || 1);
-
-    // Apply memory management to keep only recent messages
-    _applyMemoryManagement(key1);
-    _log("pipeline:load-messages:done", { cell: _cid(key1), loadedCount: validMessages.length });
-
-    return validMessages.length;
-  }
-
-  /**
-   * Apply memory management when new messages arrive
-   * Keeps only the most recent messages and removes old ones based on loaded pages
-   */
-  function _applyMemoryManagement(cellIdB64: CellIdB64): void {
-    const currentMessages = get(messages).data[cellIdB64] || {};
-    const messagesList = Object.entries(currentMessages);
-
-    // Get current pagination state to determine memory limit
-    const currentPagination = get(paginationState)[cellIdB64];
-    const loadedPages = currentPagination?.loadedPages || 1;
-
-    // Calculate memory limit: ensure users can see at least 3 pages worth of recent messages
-    // even if they haven't explicitly loaded older pages via infinite scroll
-    const effectivePages = Math.max(loadedPages, 3);
-    const maxMessagesInMemory = effectivePages * MESSAGES_PER_PAGE;
-
-    if (messagesList.length <= maxMessagesInMemory) {
-      console.log("No trimming needed - within memory limit");
-      return; // No need to trim
-    }
-
-    // Sort messages by timestamp (oldest to newest) and keep only the most recent ones
-    const sortedMessages = messagesList.sort(([, a], [, b]) => a.timestamp - b.timestamp);
-    const messagesToKeep = sortedMessages.slice(-maxMessagesInMemory);
-    const trimmedMessages = Object.fromEntries(messagesToKeep);
-
-    console.log(
-      `Trimming messages: keeping ${messagesToKeep.length} most recent out of ${sortedMessages.length} total`,
-    );
-
-    // Update the store with trimmed messages
-    messages.update((m) => ({
-      ...m,
-      [cellIdB64]: trimmedMessages,
-    }));
-
-    // Update pagination state
-    paginationState.update((state) => ({
-      ...state,
-      [cellIdB64]: {
-        ...state[cellIdB64],
-        totalMessages: messagesToKeep.length,
-        oldestLoadedTimestamp: messagesToKeep[0]?.[1].timestamp,
-      },
-    }));
-
-    const removedCount = messagesList.length - messagesToKeep.length;
-    console.log(
-      `Memory management: Removed ${removedCount} old messages, keeping ${messagesToKeep.length} recent messages (${loadedPages} loaded pages, ${effectivePages} effective pages)`,
-    );
-  }
-
-  async function _triggerMessageNotification(
-    messageExtended: MessageExtended,
-    fromProfile?: ProfileExtended,
-  ) {
-    if (messageExtended.message.message_type === MessageType.System) return;
-
-    const content =
-      messageExtended.message.content.length > 125
-        ? messageExtended.message.content.slice(0, 50) + "..."
-        : messageExtended.message.content;
-    const header = fromProfile ? `Message From ${fromProfile.profile.nickname}` : `New Message`;
-
-    await enqueueNotification(header, content);
-  }
+  // ═══════════════════════════════════════════════════════════════════════════
+  // UTILITIES
+  // ═══════════════════════════════════════════════════════════════════════════
 
   async function _makeMessageExtended(
     cellId: CellId,
     messageRecord: MessageRecord,
   ): Promise<MessageExtended> {
-    if (messageRecord.message === undefined)
+    if (!messageRecord.message)
       throw new Error("MessageRecord does not include message entry");
 
-    const baseMessage: MessageExtended = {
+    const base: MessageExtended = {
       message: messageRecord.message,
-      authorAgentPubKeyB64: encodeHashToBase64(messageRecord.signed_action.hashed.content.author),
+      authorAgentPubKeyB64: encodeHashToBase64(
+        messageRecord.signed_action.hashed.content.author,
+      ),
       timestamp: messageRecord.signed_action.hashed.content.timestamp,
     };
 
     if (messageRecord.message.images.length > 0) {
-      messageRecord.message.images.forEach((messageFile) =>
+      messageRecord.message.images.forEach((f) =>
         fileStore.download(
           encodeCellIdToBase64(cellId),
-          encodeHashToBase64(messageFile.storage_entry_hash),
+          encodeHashToBase64(f.storage_entry_hash),
         ),
       );
     }
 
-    return baseMessage;
+    return base;
+  }
+
+  async function _triggerMessageNotification(
+    messageExtended: MessageExtended,
+    fromProfile?: ProfileExtended,
+  ): Promise<void> {
+    if (messageExtended.message.message_type === MessageType.System) return;
+    const content =
+      messageExtended.message.content.length > 125
+        ? messageExtended.message.content.slice(0, 50) + "…"
+        : messageExtended.message.content;
+    await enqueueNotification(
+      fromProfile ? `Message From ${fromProfile.profile.nickname}` : "New Message",
+      content,
+    );
   }
 
   async function debugGetAllMessages(key1: CellIdB64): Promise<MessageRecord[]> {
-    let bucket = conversationStore.getBucket(key1, new Date().getTime());
+    const bucket = conversationStore.getBucket(key1, Date.now());
     const cellId = decodeCellIdFromBase64(key1);
-
-    // Get the hashes for buckets by calling them one bucket at a time.
-    // let hashes: HoloHash[] = [];
-    // while (bucket >= 0) {
-    //   console.log("getting BUCKET", bucket);
-    //   const h = await client.getMessageHashes(
-    //     cellId,
-    //     {
-    //       bucket,
-    //       count: 0,
-    //     },
-    //     true,
-    //   );
-    //   hashes = [...hashes, ...h];
-    //   bucket -= 1;
-    // }
-    // const records = await client.getMessageEntries(cellId, hashes);
-
     const records = await client.getMessagesForBuckets(
       cellId,
-      Array.from({ length: bucket + 1 }, (_, index) => index),
+      Array.from({ length: bucket + 1 }, (_, i) => i),
     );
-
-    console.log("Records", records);
+    console.log("debugGetAllMessages records:", records);
     return records;
   }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // PUBLIC INTERFACE
+  // ═══════════════════════════════════════════════════════════════════════════
 
   return {
     ...messages,
@@ -1087,6 +966,10 @@ export function createConversationMessageStore(
     debugGetAllMessages,
   };
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CELL-SCOPED DERIVED STORE
+// ─────────────────────────────────────────────────────────────────────────────
 
 export interface CellConversationMessageStore
   extends GenericKeyValueStoreReadable<MessageExtended> {
@@ -1107,14 +990,18 @@ export interface CellConversationMessageStore
   sendMessage: (content: string, files: LocalFile[]) => Promise<void>;
   sendJoinNotice: () => Promise<void>;
   handleMessageSignalReceived: (signal: MessageSignal) => Promise<void>;
-  debugGetAllMessages: () => Promise<Record[]>;
+  debugGetAllMessages: () => Promise<HolochainRecord[]>;
 }
 
 export function deriveCellConversationMessageStore(
   conversationMessageStore: ConversationMessageStore,
   key: CellIdB64,
 ) {
-  const data = deriveGenericKeyValueStore(conversationMessageStore, key, [([, m]) => m.timestamp]);
+  // Canonical sort: ascending timestamp = oldest → newest (chronological).
+  // The UI receives this order directly; no .reverse() needed anywhere.
+  const data = deriveGenericKeyValueStore(conversationMessageStore, key, [
+    ([, m]) => m.timestamp,
+  ]);
 
   return {
     ...data,

--- a/ui/src/store/ConversationMessageStore.ts
+++ b/ui/src/store/ConversationMessageStore.ts
@@ -42,7 +42,8 @@ interface PaginationState {
 
 const HARD_MEMORY_LIMIT = 500;
 
-export interface ConversationMessageStore extends GenericKeyValueStore<MessageExtended> {
+export interface ConversationMessageStore
+  extends GenericKeyValueStore<Record<ActionHashB64, MessageExtended>> {
     initialize: () => Promise<void>;
   loadMessagesInCurrentBucketTargetCount: (
     local: boolean,
@@ -93,8 +94,8 @@ export function createConversationMessageStore(
     return _getSortedMemoryEntries(cellIdB64)[0]?.[1];
   }
 
-const messages = createGenericKeyValueStore<MessageExtended>();
-  const paginationState = writable<Record<string, PaginationState>>({});
+const messages = createGenericKeyValueStore<Record<ActionHashB64, MessageExtended>>();
+const paginationState = writable<Record<string, PaginationState>>({});
 
   const { subscribe } = derived(
     [messages, mergedProfileContactInviteStore],
@@ -218,6 +219,11 @@ const messages = createGenericKeyValueStore<MessageExtended>();
       return 0;
     }
 
+    if (state.dbExhausted && state.networkExhausted) {
+      console.log("Skip: history exhausted");
+      console.groupEnd();
+    return 0;
+}
     console.log("paginationState(before):", state);
 
     const memoryBefore = _getSortedMemoryEntries(cellIdB64);
@@ -332,63 +338,86 @@ const messages = createGenericKeyValueStore<MessageExtended>();
     }
 
     console.log("No older messages found locally.");
+    markHistoryExhausted(cellIdB64);
     console.groupEnd();
     return 0;
   }
 
-  async function loadMessagesInPreviousBucketTargetCount(
-    local: boolean,
-    key1: CellIdB64,
-    targetCount = TARGET_MESSAGES_COUNT,
-    bucketChunkSize = 3,
-    maxBucketsToFetch?: number,
-  ): Promise<number> {
-    console.group(`[MessageFlow][previousBucket] ${_cid(key1)}`);
-    console.log("local:", local);
+  function markHistoryExhausted(cellIdB64: CellIdB64): void {
+  _setPaginationPartial(cellIdB64, {
+    dbExhausted: true,
+    networkExhausted: true,
+  });
 
-    const memory = _getSortedMemoryEntries(key1);
-    const oldestMessage = memory[0]?.[1];
+  _log("pagination:exhausted", { cell: _cid(cellIdB64) });
+}
 
-    console.log(
-      "memory oldest:",
-      oldestMessage
-        ? {
-            timestamp: oldestMessage.timestamp,
-            bucket: oldestMessage.message.bucket,
-            hash: memory[0][0],
-          }
-        : null,
-    );
+ async function loadMessagesInPreviousBucketTargetCount(
+  local: boolean,
+  key1: CellIdB64,
+  targetCount = TARGET_MESSAGES_COUNT,
+  bucketChunkSize = 3,
+  maxBucketsToFetch?: number,
+): Promise<number> {
+  const cursor = get(paginationState)[key1]?.oldestMemoryTimestamp;
 
-    if (!oldestMessage) {
-      console.log("No oldest message in memory");
-      console.groupEnd();
-      return 0;
-    }
+  console.group(`[MessageFlow][previousBucket] ${_cid(key1)}`);
+  console.log("local:", local);
+  console.log("cursor:", cursor);
 
-    const oldestBucket = oldestMessage.message.bucket;
-    console.log("using oldest message.bucket:", oldestBucket);
-    console.log("requesting start bucket:", oldestBucket - 1);
-
-    if (oldestBucket <= 0) {
-      console.log("Already at earliest bucket");
-      console.groupEnd();
-      return 0;
-    }
-
-    const result = await _loadFromBucketPipeline(
-      local,
-      key1,
-      oldestBucket - 1,
-      targetCount,
-      bucketChunkSize,
-      maxBucketsToFetch,
-    );
-
-    console.log("result:", result);
+  if (!cursor) {
+    console.log("No cursor");
     console.groupEnd();
-    return result;
+    return 0;
   }
+
+  const memory = Object.entries(get(messages).data[key1] || {}).sort(
+    ([, a], [, b]) => a.timestamp - b.timestamp,
+  );
+
+  const oldestMsg = memory[0]?.[1];
+
+  console.log(
+    "memory oldest:",
+    oldestMsg
+      ? {
+          timestamp: oldestMsg.timestamp,
+          bucket: oldestMsg.message.bucket,
+        }
+      : null,
+  );
+
+  if (!oldestMsg) {
+    console.log("No oldest message in memory");
+    console.groupEnd();
+    return 0;
+  }
+
+  const oldestBucket = oldestMsg.message.bucket;
+  console.log("using oldest message.bucket:", oldestBucket);
+
+  if (oldestBucket <= 0) {
+    console.log("Already at earliest bucket");
+    markHistoryExhausted(key1);
+    console.groupEnd();
+    return 0;
+  }
+
+  console.log("requesting start bucket:", oldestBucket - 1);
+
+  const result = await _loadFromBucketPipeline(
+    local,
+    key1,
+    oldestBucket - 1,
+    targetCount,
+    bucketChunkSize,
+    maxBucketsToFetch,
+  );
+
+  console.log("result:", result);
+  console.groupEnd();
+  return result;
+}
 
   function _mergeOlderIntoMemory(
     cellIdB64: CellIdB64,
@@ -973,7 +1002,7 @@ const messages = createGenericKeyValueStore<MessageExtended>();
 }
 
 export interface CellConversationMessageStore
-  extends GenericKeyValueStoreReadable<MessageExtended> {
+  extends GenericKeyValueStoreReadable<Record<ActionHashB64, MessageExtended>> {
   initialize: () => Promise<void>;
   loadMessagesInCurrentBucketTargetCount: (
     local: boolean,

--- a/ui/src/store/ConversationMessageStore.ts
+++ b/ui/src/store/ConversationMessageStore.ts
@@ -78,6 +78,18 @@ export function createConversationMessageStore(
   mergedProfileContactInviteStore: MergedProfileContactInviteStore,
   fileStore: FileStore,
 ): ConversationMessageStore {
+  function _cid(cellIdB64: CellIdB64) {
+    return cellIdB64.slice(0, 10);
+  }
+
+  function _log(stage: string, details?: { [key: string]: unknown }) {
+    if (details) {
+      console.log(`[MessageFlow] ${stage}`, details);
+    } else {
+      console.log(`[MessageFlow] ${stage}`);
+    }
+  }
+
   // In-memory store holds only active messages (limited by pagination)
   const messages = createGenericKeyKeyValueStore<MessageExtended>();
 
@@ -134,6 +146,7 @@ export function createConversationMessageStore(
   );
 
   async function initialize() {
+    _log("initialize:start");
     const cellInfos = await client.getRelayClonedCellInfos();
     // Log all Cell IDs for debugging
     cellInfos.forEach((cellInfo, index) => {
@@ -160,12 +173,17 @@ export function createConversationMessageStore(
       cellInfos.map(async (cellInfo) => {
         const cellIdB64 = encodeCellIdToBase64(cellInfo.cell_id);
 
+        _log("initialize:conversation:start", { cell: _cid(cellIdB64) });
+
         await _loadMessagesFromDB(cellIdB64, 1); // Load first page
 
         // If no messages in DB, try to fetch from network
         const currentState = get(paginationState)[cellIdB64];
 
         if (currentState.totalMessages === 0) {
+          _log("initialize:conversation:db-empty -> backfill-current-buckets", {
+            cell: _cid(cellIdB64),
+          });
           // when first initializing go local
           await loadMessagesInCurrentBucketTargetCount(
             true,
@@ -175,6 +193,13 @@ export function createConversationMessageStore(
             50,
           );
         }
+
+        const finalState = get(paginationState)[cellIdB64];
+        _log("initialize:conversation:done", {
+          cell: _cid(cellIdB64),
+          loadedPages: finalState?.loadedPages,
+          totalMessages: finalState?.totalMessages,
+        });
       }),
     );
 
@@ -185,7 +210,7 @@ export function createConversationMessageStore(
       }
     });
 
-    console.log(" Initialization complete");
+    _log("initialize:complete", { conversations: cellInfos.length });
   }
 
   /**
@@ -195,12 +220,13 @@ export function createConversationMessageStore(
   async function _loadMessagesFromDB(cellIdB64: CellIdB64, pagesToLoad: number): Promise<void> {
     try {
       const limit = pagesToLoad * MESSAGES_PER_PAGE;
+      _log("db:load:start", { cell: _cid(cellIdB64), pagesToLoad, limit });
 
       // Check if agent changed and clear cache if needed
       const cacheCleared = await messageDB.clearCacheOnAgentChange(cellIdB64);
 
       const dbMessages = await messageDB.getMessages(cellIdB64, limit);
-      console.log(` Retrieved ${dbMessages.length} messages from IndexedDB`);
+      _log("db:load:result", { cell: _cid(cellIdB64), count: dbMessages.length });
 
       if (dbMessages.length > 0) {
         // Sort messages by timestamp (newest to oldest) for natural chat order
@@ -232,8 +258,13 @@ export function createConversationMessageStore(
             oldestLoadedTimestamp: messagesToKeep[messagesToKeep.length - 1]?.[1].timestamp, // Last (oldest) message in memory
           },
         }));
+        _log("db:load:memory-updated", {
+          cell: _cid(cellIdB64),
+          loadedPages: pagesToLoad,
+          memoryCount: messagesToKeep.length,
+        });
       } else {
-        console.warn(`No messages found in IndexedDB for cell ${cellIdB64.substring(0, 10)}...`);
+        _log("db:load:empty", { cell: _cid(cellIdB64) });
       }
     } catch (error) {
       console.error(" Error loading messages from DB:", error);
@@ -246,12 +277,19 @@ export function createConversationMessageStore(
   async function loadMoreMessages(cellIdB64: CellIdB64): Promise<number> {
     const currentState = get(paginationState)[cellIdB64];
     if (!currentState?.oldestLoadedTimestamp) {
+      _log("scroll-up:skip:no-oldest-timestamp", { cell: _cid(cellIdB64) });
       return 0;
     }
 
+    _log("scroll-up:start", {
+      cell: _cid(cellIdB64),
+      oldestLoadedTimestamp: currentState.oldestLoadedTimestamp,
+      loadedPages: currentState.loadedPages,
+    });
+
     try {
       // First, try to load from IndexedDB
-      const olderMessages = await messageDB.getOlderMessages(
+      let olderMessages = await messageDB.getOlderMessages(
         cellIdB64,
         currentState.oldestLoadedTimestamp,
         MESSAGES_PER_PAGE,
@@ -259,105 +297,140 @@ export function createConversationMessageStore(
 
       let loadedCount = 0;
 
+      _log("scroll-up:db-check", { cell: _cid(cellIdB64), olderDbCount: olderMessages.length });
+
       if (olderMessages.length > 0) {
-        // Get current messages and sort them by timestamp (newest to oldest) for natural chat order
-        const currentMessages = get(messages).data[cellIdB64] || {};
-        const currentMessagesList = Object.entries(currentMessages).sort(
-          ([, a], [, b]) => b.timestamp - a.timestamp,
-        );
-
-        // Combine older messages with current ones - older messages go at the end (bottom)
-        const allMessages = [...currentMessagesList, ...olderMessages];
-
-        // Calculate new loaded pages count
-        const newLoadedPages = currentState.loadedPages + 1;
-        const maxMessagesInMemory = newLoadedPages * MESSAGES_PER_PAGE;
-
-        // Apply memory management: keep only the most recent messages within limit
-        const messagesToKeep = allMessages.slice(0, maxMessagesInMemory);
-        const updatedMessages = Object.fromEntries(messagesToKeep);
-        messages.update((m) => ({
-          ...m,
-          [cellIdB64]: updatedMessages,
-        }));
-
-        paginationState.update((state) => ({
-          ...state,
-          [cellIdB64]: {
-            ...state[cellIdB64],
-            loadedPages: newLoadedPages,
-            totalMessages: messagesToKeep.length,
-            oldestLoadedTimestamp: messagesToKeep[messagesToKeep.length - 1]?.[1].timestamp,
-          },
-        }));
+        _appendOlderMessagesToMemory(cellIdB64, olderMessages);
+        loadedCount = olderMessages.length;
+        _log("scroll-up:served-from-db", { cell: _cid(cellIdB64), loadedCount });
       }
 
-      // This shouldn't be done, it will only likely trigger timeouts.  Unless the node is zero-arc (which we are not doing in Volla), all loading should be local.
-      // Data will be synced quickly and so it's not worth trying to get it from the network.
+      // If local DB has no older rows, backfill DB using the standard
+      // bucket -> hashes -> missing entries pipeline, then try local DB again.
       if (olderMessages.length === 0) {
-        console.log(`Local DB empty. Using reliable backend sync...`);
+        _log("scroll-up:db-empty -> pipeline-backfill", { cell: _cid(cellIdB64) });
 
         try {
-          const cellId = decodeCellIdFromBase64(cellIdB64);
+          const backfilledCount = await _backfillOlderMessagesToDB(cellIdB64);
+          _log("scroll-up:pipeline-backfill:result", {
+            cell: _cid(cellIdB64),
+            backfilledCount,
+          });
 
-          // 1. Get the actual oldest message from memory to find its exact bucket
-          const currentMessages = get(messages).data[cellIdB64] || {};
-          const messagesList = Object.entries(currentMessages).sort(
-            ([, a], [, b]) => a.timestamp - b.timestamp,
-          );
-          const oldestMessage = messagesList[0]?.[1];
-
-          if (!oldestMessage) return 0;
-
-          // 2. Read the bucket directly from the message object (No timestamp math!)
-          const oldestBucket = oldestMessage.message.bucket;
-
-          // 3. Safely ask for just the next 3 older buckets
-          const targetBuckets = [oldestBucket - 1, oldestBucket - 2, oldestBucket - 3].filter(
-            (b) => b >= 0,
-          );
-
-          if (targetBuckets.length > 0) {
-            console.log(`Fetching buckets directly from DHT:`, targetBuckets);
-
-            const messageRecords = await client.getMessagesForBuckets(cellId, targetBuckets);
-
-            if (messageRecords.length > 0) {
-              const messageEntries = await Promise.allSettled(
-                messageRecords.map(
-                  async (m) =>
-                    [
-                      encodeHashToBase64(m.original_action),
-                      await _makeMessageExtended(cellId, m),
-                    ] as [ActionHashB64, MessageExtended],
-                ),
-              );
-
-              const validMessages = messageEntries
-                .filter((p) => p.status === "fulfilled")
-                .map((p: any) => p.value);
-
-              await messageDB.storeMessages(cellIdB64, validMessages);
-              await _loadMessagesFromDB(cellIdB64, currentState.loadedPages + 1);
-              _applyMemoryManagement(cellIdB64);
-
-              loadedCount = validMessages.length;
-              console.log(`[Network Fetch] Success! Downloaded and saved ${loadedCount} messages.`);
-            } else {
-              console.log(`[Network Fetch] DHT returned 0 messages for those buckets.`);
+          if (backfilledCount > 0) {
+            const stateAfterBackfill = get(paginationState)[cellIdB64];
+            if (!stateAfterBackfill?.oldestLoadedTimestamp) {
+              return loadedCount;
             }
+            olderMessages = await messageDB.getOlderMessages(
+              cellIdB64,
+              stateAfterBackfill.oldestLoadedTimestamp,
+              MESSAGES_PER_PAGE,
+            );
+            _log("scroll-up:db-retry-after-backfill", {
+              cell: _cid(cellIdB64),
+              olderDbCount: olderMessages.length,
+            });
+
+            if (olderMessages.length > 0) {
+              _appendOlderMessagesToMemory(cellIdB64, olderMessages);
+              loadedCount = olderMessages.length;
+              _log("scroll-up:served-after-backfill", {
+                cell: _cid(cellIdB64),
+                backfilledCount,
+                loadedCount,
+              });
+            }
+          } else {
+            _log("scroll-up:backfill-no-data", { cell: _cid(cellIdB64) });
           }
         } catch (error) {
-          console.error(` [Network Fetch] FAILED:`, error);
+          console.error(` [Pipeline Backfill] FAILED:`, error);
           loadedCount = 0;
         }
       }
+
+      _log("scroll-up:done", { cell: _cid(cellIdB64), loadedCount });
 
       return loadedCount;
     } catch (error) {
       console.error("Error loading more messages:", error);
       return 0;
     }
+  }
+
+  function _appendOlderMessagesToMemory(
+    cellIdB64: CellIdB64,
+    olderMessages: [ActionHashB64, MessageExtended][],
+  ) {
+    const currentState = get(paginationState)[cellIdB64] || { loadedPages: 0, totalMessages: 0 };
+
+    // Get current messages and sort them by timestamp (newest to oldest) for natural chat order
+    const currentMessages = get(messages).data[cellIdB64] || {};
+    const currentMessagesList = Object.entries(currentMessages).sort(([, a], [, b]) => b.timestamp - a.timestamp);
+    _log("memory:append-older:start", {
+      cell: _cid(cellIdB64),
+      currentMemoryCount: currentMessagesList.length,
+      olderIncomingCount: olderMessages.length,
+    });
+
+    // Combine older messages with current ones - older messages go at the end (bottom)
+    const allMessages = [...currentMessagesList, ...olderMessages];
+
+    // Calculate new loaded pages count
+    const newLoadedPages = currentState.loadedPages + 1;
+    const maxMessagesInMemory = newLoadedPages * MESSAGES_PER_PAGE;
+
+    // Apply memory management: keep only the most recent messages within limit
+    const messagesToKeep = allMessages.slice(0, maxMessagesInMemory);
+    const updatedMessages = Object.fromEntries(messagesToKeep);
+    messages.update((m) => ({
+      ...m,
+      [cellIdB64]: updatedMessages,
+    }));
+
+    paginationState.update((state) => ({
+      ...state,
+      [cellIdB64]: {
+        ...state[cellIdB64],
+        loadedPages: newLoadedPages,
+        totalMessages: messagesToKeep.length,
+        oldestLoadedTimestamp: messagesToKeep[messagesToKeep.length - 1]?.[1].timestamp,
+      },
+    }));
+
+    _log("memory:append-older:done", {
+      cell: _cid(cellIdB64),
+      newLoadedPages,
+      keptInMemory: messagesToKeep.length,
+    });
+  }
+
+  async function _backfillOlderMessagesToDB(cellIdB64: CellIdB64): Promise<number> {
+    const currentMessages = get(messages).data[cellIdB64] || {};
+    const messagesList = Object.entries(currentMessages).sort(([, a], [, b]) => a.timestamp - b.timestamp);
+    const oldestMessage = messagesList[0]?.[1];
+
+    if (!oldestMessage) return 0;
+
+    const oldestBucket = oldestMessage.message.bucket;
+    if (oldestBucket <= 0) return 0;
+
+    // Use the same underlying bucket/hash/entry pipeline used elsewhere.
+    _log("pipeline-backfill:start", {
+      cell: _cid(cellIdB64),
+      fromBucket: oldestBucket - 1,
+      oldestBucket,
+    });
+
+    return _loadMessagesFromBucketTargetCount(
+      true,
+      cellIdB64,
+      oldestBucket - 1,
+      TARGET_MESSAGES_COUNT,
+      3,
+      3,
+    );
   }
 
   async function sendMessage(key1: CellIdB64, content: string, files: LocalFile[]) {
@@ -699,6 +772,15 @@ export function createConversationMessageStore(
     bucketChunkSize: number = 3,
     maxBucketsToFetch?: number,
   ): Promise<number> {
+    _log("pipeline:bucket-target:start", {
+      cell: _cid(key1),
+      local,
+      bucket,
+      targetCount,
+      bucketChunkSize,
+      maxBucketsToFetch,
+    });
+
     // Fetch the list of buckets that contain the target count
     const bucketsToFetch = await _fetchBucketsTargetCount(
       key1,
@@ -708,13 +790,25 @@ export function createConversationMessageStore(
       bucketChunkSize,
       maxBucketsToFetch,
     );
+    _log("pipeline:bucket-target:fetched-buckets", {
+      cell: _cid(key1),
+      bucketsFetched: bucketsToFetch.length,
+      totalHashes: sum(bucketsToFetch.map(({ actionHashB64s }) => actionHashB64s.length)),
+    });
+
     const actionHashB64s = flatten(bucketsToFetch.map(({ actionHashB64s }) => actionHashB64s));
 
     // Filter only messages we are not storing already (check IndexedDB)
     const missingActionHashB64s = await _filterMissingMessagesFromDB(key1, actionHashB64s);
+    _log("pipeline:bucket-target:missing-after-db-filter", {
+      cell: _cid(key1),
+      totalHashes: actionHashB64s.length,
+      missingCount: missingActionHashB64s.length,
+    });
 
     // Fetch and save missing message data
     const count = await _loadMessages(key1, missingActionHashB64s);
+    _log("pipeline:bucket-target:done", { cell: _cid(key1), loadedCount: count });
 
     return count;
   }
@@ -740,6 +834,7 @@ export function createConversationMessageStore(
       (maxBucketsToFetch === undefined || bucketsToFetch.length <= maxBucketsToFetch)
     ) {
       const bucketsChunk = range(bucket, bucket - bucketChunkSize).filter((b) => b >= 0);
+      _log("pipeline:bucket-scan:chunk", { cell: _cid(key1), bucketsChunk, local });
       bucketsToFetch = [
         ...bucketsToFetch,
         ...(await Promise.all(
@@ -791,7 +886,12 @@ export function createConversationMessageStore(
   }
 
   async function _loadMessages(key1: CellIdB64, actionHashB64s: ActionHashB64[]): Promise<number> {
-    if (actionHashB64s.length === 0) return 0;
+    if (actionHashB64s.length === 0) {
+      _log("pipeline:load-messages:skip-no-missing-hashes", { cell: _cid(key1) });
+      return 0;
+    }
+
+    _log("pipeline:load-messages:start", { cell: _cid(key1), missingHashes: actionHashB64s.length });
 
     const cellId = decodeCellIdFromBase64(key1);
 
@@ -801,6 +901,10 @@ export function createConversationMessageStore(
       actionHashB64s.map((a) => decodeHashFromBase64(a)),
       false,
     );
+    _log("pipeline:load-messages:fetched-records", {
+      cell: _cid(key1),
+      fetchedRecords: messageRecords.length,
+    });
 
     // Transform Messages into MessageExtendeds
     const messageEntries = await Promise.allSettled(
@@ -817,7 +921,10 @@ export function createConversationMessageStore(
       .filter((p) => p.status === "fulfilled")
       .map((p) => p.value);
 
-    if (validMessages.length === 0) return 0;
+    if (validMessages.length === 0) {
+      _log("pipeline:load-messages:no-valid-messages", { cell: _cid(key1) });
+      return 0;
+    }
 
     console.group(" SAVING TO INDEXEDDB");
     console.log(`Cell ID: ${key1.substring(0, 15)}...`);
@@ -827,12 +934,17 @@ export function createConversationMessageStore(
 
     // Store in IndexedDB first
     await messageDB.storeMessages(key1, validMessages);
+    _log("pipeline:load-messages:stored-to-db", {
+      cell: _cid(key1),
+      storedCount: validMessages.length,
+    });
 
     // Load appropriate messages into memory store based on current pagination
     await _loadMessagesFromDB(key1, get(paginationState)[key1]?.loadedPages || 1);
 
     // Apply memory management to keep only recent messages
     _applyMemoryManagement(key1);
+    _log("pipeline:load-messages:done", { cell: _cid(key1), loadedCount: validMessages.length });
 
     return validMessages.length;
   }
@@ -1002,7 +1114,7 @@ export function deriveCellConversationMessageStore(
   conversationMessageStore: ConversationMessageStore,
   key: CellIdB64,
 ) {
-  const data = deriveGenericKeyValueStore(conversationMessageStore, key, [([, m]) => -m.timestamp]);
+  const data = deriveGenericKeyValueStore(conversationMessageStore, key, [([, m]) => m.timestamp]);
 
   return {
     ...data,

--- a/ui/src/store/ConversationMessageStore.ts
+++ b/ui/src/store/ConversationMessageStore.ts
@@ -1,24 +1,3 @@
-/**
- * ConversationMessageStore — production-grade rewrite
- *
- * Architecture:
- *   - Canonical internal order is insertion order in a plain JS object
- *     { [hash]: MessageExtended }.  All sorted output uses timestamp ASC
- *     via the deriveGenericKeyValueStore listSortBy parameter.
- *   - Memory is unbounded during normal use; a hard cap of HARD_MEMORY_LIMIT
- *     (500) evicts oldest entries only during scroll-up prepend.
- *   - Three-state pagination cursor:
- *       oldestMemoryTimestamp  – cursor for the next DB page query
- *       dbExhausted            – DB has no rows older than the cursor
- *       networkExhausted       – Holochain returned 0 hashes for older buckets
- *   - Signal-first dedup: existing in-memory entries always win on merge.
- *   - loadMoreMessages is the only path that prepends older messages.
- *     It never calls _initLoadFromDB (which is init-only).
- *   - _fetchAndStoreTooDB stores to DB only; it never touches in-memory state.
- *   - Polling (_loadFromBucketPipeline) hydrates memory from the newest DB
- *     records after storing, using signal-first merge.
- */
-
 import {
   type CellIdB64,
   type LocalFile,
@@ -37,55 +16,34 @@ import {
   encodeHashToBase64,
   type ActionHashB64,
   type CellId,
-  type Record as HolochainRecord,
 } from "@holochain/client";
 import { flatten, range, sum } from "lodash-es";
 import type { ConversationStore } from "./ConversationStore";
 import {
-  createGenericKeyKeyValueStore,
-  deriveGenericKeyValueStore,
-  type GenericKeyKeyValueStore,
-} from "./generic/GenericKeyKeyValueStore";
+  createGenericKeyValueStore,
+  type GenericKeyValueStore,
+  type GenericKeyValueStoreReadable,
+} from "./generic/GenericKeyValueStore";
 import {
   deriveCellMergedProfileContactInviteStore,
   type MergedProfileContactInviteStore,
 } from "./MergedProfileContactInviteStore";
 import type { RelayClient } from "./RelayClient";
 import { derived, get, writable } from "svelte/store";
-import type { GenericKeyValueStoreReadable } from "./generic/GenericKeyValueStore";
 import { TARGET_MESSAGES_COUNT, MESSAGES_PER_PAGE } from "$config";
 import type { FileStore } from "./FileStore";
 import { messageDB } from "./db/MessageDatabase";
 
-// ── Pagination cursor ─────────────────────────────────────────────────────────
-//
-// oldestMemoryTimestamp
-//   Timestamp of the oldest message currently held in the in-memory store.
-//   Used as the exclusive upper-bound for the next getOlderMessages() DB call.
-//   Recomputed after every operation that could change the oldest end of memory.
-//
-// dbExhausted
-//   Set true when the local DB returns 0 rows older than oldestMemoryTimestamp.
-//   Reset to false after a network backfill writes new messages into the DB.
-//
-// networkExhausted
-//   Set true when Holochain returns 0 action-hashes for all queried buckets
-//   before the cursor bucket.  Prevents infinite retries at history start.
-// ─────────────────────────────────────────────────────────────────────────────
 interface PaginationState {
   oldestMemoryTimestamp: number | undefined;
   dbExhausted: boolean;
   networkExhausted: boolean;
 }
 
-// Only evict old messages during scroll-up prepend, and only if memory
-// exceeds this generous limit. Most conversations never reach it.
 const HARD_MEMORY_LIMIT = 500;
 
-// ── Public store interface ────────────────────────────────────────────────────
-
-export interface ConversationMessageStore extends GenericKeyKeyValueStore<MessageExtended> {
-  initialize: () => Promise<void>;
+export interface ConversationMessageStore extends GenericKeyValueStore<MessageExtended> {
+    initialize: () => Promise<void>;
   loadMessagesInCurrentBucketTargetCount: (
     local: boolean,
     key1: CellIdB64,
@@ -112,31 +70,32 @@ export interface ConversationMessageStore extends GenericKeyKeyValueStore<Messag
   debugGetAllMessages: (key1: CellIdB64) => Promise<MessageRecord[]>;
 }
 
-// ── Factory ───────────────────────────────────────────────────────────────────
-
 export function createConversationMessageStore(
   client: RelayClient,
   conversationStore: ConversationStore,
   mergedProfileContactInviteStore: MergedProfileContactInviteStore,
   fileStore: FileStore,
 ): ConversationMessageStore {
-
-  function _cid(id: CellIdB64): string { return id.slice(0, 10); }
+  function _cid(id: CellIdB64): string {
+    return id.slice(0, 10);
+  }
 
   function _log(stage: string, details?: { [key: string]: unknown }): void {
     if (details) console.log(`[MessageFlow] ${stage}`, details);
     else console.log(`[MessageFlow] ${stage}`);
   }
 
-  // ── Internal raw store: { [cellIdB64]: { [hash]: MessageExtended } } ────────
-  const messages = createGenericKeyKeyValueStore<MessageExtended>();
+  function _getSortedMemoryEntries(cellIdB64: CellIdB64): [ActionHashB64, MessageExtended][] {
+    return Object.entries(get(messages).data[cellIdB64] || {}).sort(([, a], [, b]) => a.timestamp - b.timestamp);
+  }
 
-  // ── Per-conversation pagination state ─────────────────────────────────────
-  const paginationState = writable<{ [cellIdB64: CellIdB64]: PaginationState }>({});
+  function _getOldestMessage(cellIdB64: CellIdB64): MessageExtended | undefined {
+    return _getSortedMemoryEntries(cellIdB64)[0]?.[1];
+  }
 
-  // ── Filtered public subscribe ──────────────────────────────────────────────
-  // Hides messages from agents with no known profile/contact unless profiles
-  // haven't loaded yet (prevents a race condition on first open).
+const messages = createGenericKeyValueStore<MessageExtended>();
+  const paginationState = writable<Record<string, PaginationState>>({});
+
   const { subscribe } = derived(
     [messages, mergedProfileContactInviteStore],
     ([$messages, $mergedProfileContactInviteStore]) => {
@@ -148,8 +107,9 @@ export function createConversationMessageStore(
           const filtered = Object.entries(messagesData).filter(([, msg]) => {
             if (!profilesLoaded) return true;
             if (msg.message.message_type === MessageType.System) return true;
+
             return (
-              $mergedProfileContactInviteStore.data[cellIdB64][msg.authorAgentPubKeyB64] !==
+              $mergedProfileContactInviteStore.data[cellIdB64]?.[msg.authorAgentPubKeyB64] !==
               undefined
             );
           });
@@ -166,23 +126,23 @@ export function createConversationMessageStore(
     },
   );
 
-  // ═══════════════════════════════════════════════════════════════════════════
-  // INITIALIZE
-  // ═══════════════════════════════════════════════════════════════════════════
-
   async function initialize(): Promise<void> {
     _log("initialize:start");
     const cellInfos = await client.getRelayClonedCellInfos();
 
-    // Seed empty maps for every known conversation cell
     messages.set(
       Object.fromEntries(cellInfos.map((ci) => [encodeCellIdToBase64(ci.cell_id), {}])),
     );
+
     paginationState.set(
       Object.fromEntries(
         cellInfos.map((ci) => [
           encodeCellIdToBase64(ci.cell_id),
-          { oldestMemoryTimestamp: undefined, dbExhausted: false, networkExhausted: false },
+          {
+            oldestMemoryTimestamp: undefined,
+            dbExhausted: false,
+            networkExhausted: false,
+          },
         ]),
       ),
     );
@@ -192,15 +152,17 @@ export function createConversationMessageStore(
         const cellIdB64 = encodeCellIdToBase64(cellInfo.cell_id);
         _log("initialize:cell:start", { cell: _cid(cellIdB64) });
 
-        // 1. Load most-recent page from local DB (signal-first merge)
         await _initLoadFromDB(cellIdB64);
 
-        // 2. If DB was empty, bootstrap from Holochain (local-first for speed)
         const memCount = Object.keys(get(messages).data[cellIdB64] || {}).length;
         if (memCount === 0) {
           _log("initialize:cell:db-empty→network-bootstrap", { cell: _cid(cellIdB64) });
           await loadMessagesInCurrentBucketTargetCount(
-            true, cellIdB64, TARGET_MESSAGES_COUNT, 10, 50,
+            true,
+            cellIdB64,
+            TARGET_MESSAGES_COUNT,
+            10,
+            50,
           );
         }
 
@@ -213,39 +175,30 @@ export function createConversationMessageStore(
     );
 
     results.forEach((r, i) => {
-      if (r.status === "rejected")
+      if (r.status === "rejected") {
         console.error(`[init] cell ${i} failed:`, r.reason);
+      }
     });
 
     _log("initialize:complete", { cells: cellInfos.length });
   }
 
-  // ═══════════════════════════════════════════════════════════════════════════
-  // DB → MEMORY  (init only)
-  // ═══════════════════════════════════════════════════════════════════════════
-
-  /**
-   * Load the most-recent MESSAGES_PER_PAGE messages from IndexedDB into memory.
-   * Used ONLY during initialization; never called from loadMoreMessages.
-   *
-   * Signal-first: if a message is already in memory (e.g., arrived via signal
-   * before init finished) the in-memory copy wins — DB data is never applied
-   * on top of a live entry.
-   */
   async function _initLoadFromDB(cellIdB64: CellIdB64): Promise<void> {
     try {
       await messageDB.clearCacheOnAgentChange(cellIdB64);
       const dbMessages = await messageDB.getMessages(cellIdB64, MESSAGES_PER_PAGE);
       _log("db:init-load", { cell: _cid(cellIdB64), count: dbMessages.length });
+
       if (dbMessages.length === 0) return;
 
-      // Signal-first merge
       messages.update((m) => {
         const existing = m[cellIdB64] || {};
         const merged = { ...existing };
+
         for (const [hash, msg] of dbMessages) {
           if (!(hash in merged)) merged[hash] = msg;
         }
+
         return { ...m, [cellIdB64]: merged };
       });
 
@@ -255,103 +208,188 @@ export function createConversationMessageStore(
     }
   }
 
-  // ═══════════════════════════════════════════════════════════════════════════
-  // SCROLL-UP PAGINATION
-  // ═══════════════════════════════════════════════════════════════════════════
-
-  /**
-   * Load the next page of older messages for infinite-scroll.
-   *
-   * Strategy:
-   *   1. Query local DB for messages older than oldestMemoryTimestamp.
-   *   2. If DB is exhausted, run a network backfill then re-query DB.
-   *   3. Merge results into memory (signal-first, no trim on the newest end).
-   *
-   * Returns the number of messages actually new to the in-memory store.
-   */
   async function loadMoreMessages(cellIdB64: CellIdB64): Promise<number> {
     const state = get(paginationState)[cellIdB64];
-    if (!state) return 0;
+    console.group(`[MessageFlow][loadMoreMessages] ${_cid(cellIdB64)}`);
+
+    if (!state) {
+      console.log("No pagination state");
+      console.groupEnd();
+      return 0;
+    }
+
+    console.log("paginationState(before):", state);
+
+    const memoryBefore = _getSortedMemoryEntries(cellIdB64);
+
+    console.log("memory count(before):", memoryBefore.length);
+    console.log(
+      "oldest memory(before):",
+      memoryBefore[0]?.[1]
+        ? {
+            timestamp: memoryBefore[0][1].timestamp,
+            bucket: memoryBefore[0][1].message.bucket,
+            hash: memoryBefore[0][0],
+          }
+        : null,
+    );
+    console.log(
+      "newest memory(before):",
+      memoryBefore[memoryBefore.length - 1]?.[1]
+        ? {
+            timestamp: memoryBefore[memoryBefore.length - 1][1].timestamp,
+            bucket: memoryBefore[memoryBefore.length - 1][1].message.bucket,
+            hash: memoryBefore[memoryBefore.length - 1][0],
+          }
+        : null,
+    );
 
     const cursor = state.oldestMemoryTimestamp;
+    console.log("cursor:", cursor);
+
     if (cursor === undefined) {
-      _log("scroll-up:skip:no-cursor", { cell: _cid(cellIdB64) });
+      console.log("Skip: no cursor");
+      console.groupEnd();
       return 0;
     }
 
-    if (state.networkExhausted) {
-      _log("scroll-up:skip:network-exhausted", { cell: _cid(cellIdB64) });
-      return 0;
-    }
-
-    _log("scroll-up:start", { cell: _cid(cellIdB64), cursor, ...state });
-
-    // ── 1. Local DB ────────────────────────────────────────────────────────
-    if (!state.dbExhausted) {
-      const olderMsgs = await messageDB.getOlderMessages(cellIdB64, cursor, MESSAGES_PER_PAGE);
-      _log("scroll-up:db-result", { cell: _cid(cellIdB64), count: olderMsgs.length });
-
-      if (olderMsgs.length > 0) {
-        const added = _mergeOlderIntoMemory(cellIdB64, olderMsgs);
-        _log("scroll-up:served-from-db", { cell: _cid(cellIdB64), added });
-        return added;
-      }
-
-      // DB has nothing older than the cursor — mark exhausted, try network.
-      _setPaginationPartial(cellIdB64, { dbExhausted: true });
-    }
-
-    // ── 2. Network backfill ────────────────────────────────────────────────
-    _log("scroll-up:network-backfill-start", { cell: _cid(cellIdB64), cursor });
-    const { newlyStored, noMoreOnNetwork } = await _backfillOlderMessagesToDB(
-      cellIdB64,
-      cursor,
-    );
-    _log("scroll-up:network-backfill-result", {
-      cell: _cid(cellIdB64),
-      newlyStored,
-      noMoreOnNetwork,
-    });
-
-    if (noMoreOnNetwork) {
-      _setPaginationPartial(cellIdB64, { networkExhausted: true });
-      return 0;
-    }
-
-    // Re-query DB with the same cursor. Works whether newlyStored > 0
-    // (fresh data) or == 0 (all hashes already in DB but not in memory).
     const olderMsgs = await messageDB.getOlderMessages(cellIdB64, cursor, MESSAGES_PER_PAGE);
-    _log("scroll-up:db-retry-after-backfill", {
-      cell: _cid(cellIdB64),
-      count: olderMsgs.length,
-    });
+    console.log("IndexedDB olderMsgs count:", olderMsgs.length);
+    console.log(
+      "IndexedDB olderMsgs sample:",
+      olderMsgs.slice(0, 3).map(([hash, msg]) => ({
+        hash,
+        timestamp: msg.timestamp,
+        bucket: msg.message.bucket,
+        type: msg.message.message_type,
+      })),
+    );
 
     if (olderMsgs.length > 0) {
-      _setPaginationPartial(cellIdB64, { dbExhausted: false });
       const added = _mergeOlderIntoMemory(cellIdB64, olderMsgs);
-      _log("scroll-up:served-after-backfill", { cell: _cid(cellIdB64), added });
+      console.log("Merged older messages from DB. added:", added);
+
+      const memoryAfter = _getSortedMemoryEntries(cellIdB64);
+
+      console.log("memory count(after DB merge):", memoryAfter.length);
+      console.log(
+        "oldest memory(after DB merge):",
+        memoryAfter[0]?.[1]
+          ? {
+              timestamp: memoryAfter[0][1].timestamp,
+              bucket: memoryAfter[0][1].message.bucket,
+              hash: memoryAfter[0][0],
+            }
+          : null,
+      );
+      console.groupEnd();
       return added;
     }
 
-    // Backfill ran, DB still returns 0. Edge case: all hashes already in DB
-    // but their timestamps are >= cursor (clock-skew). Do not mark network
-    // exhausted — caller can retry; we just can't serve a page right now.
-    _log("scroll-up:done:no-results-after-backfill", { cell: _cid(cellIdB64) });
+    console.log("IndexedDB returned 0 older rows. Trying LOCAL previous-bucket pipeline...");
+
+    const loadedViaLocalPipeline = await loadMessagesInPreviousBucketTargetCount(
+      true,
+      cellIdB64,
+      TARGET_MESSAGES_COUNT,
+      3,
+      3,
+    );
+
+    console.log("loadedViaLocalPipeline:", loadedViaLocalPipeline);
+
+    const olderMsgsAfterPipeline = await messageDB.getOlderMessages(cellIdB64, cursor, MESSAGES_PER_PAGE);
+    console.log("IndexedDB olderMsgs AFTER local pipeline:", olderMsgsAfterPipeline.length);
+    console.log(
+      "IndexedDB olderMsgs AFTER local pipeline sample:",
+      olderMsgsAfterPipeline.slice(0, 3).map(([hash, msg]) => ({
+        hash,
+        timestamp: msg.timestamp,
+        bucket: msg.message.bucket,
+        type: msg.message.message_type,
+      })),
+    );
+
+    if (olderMsgsAfterPipeline.length > 0) {
+      const added = _mergeOlderIntoMemory(cellIdB64, olderMsgsAfterPipeline);
+      console.log("Merged older messages after local pipeline. added:", added);
+
+      const memoryAfter = _getSortedMemoryEntries(cellIdB64);
+
+      console.log("memory count(after local pipeline merge):", memoryAfter.length);
+      console.log(
+        "oldest memory(after local pipeline merge):",
+        memoryAfter[0]?.[1]
+          ? {
+              timestamp: memoryAfter[0][1].timestamp,
+              bucket: memoryAfter[0][1].message.bucket,
+              hash: memoryAfter[0][0],
+            }
+          : null,
+      );
+      console.groupEnd();
+      return added;
+    }
+
+    console.log("No older messages found locally.");
+    console.groupEnd();
     return 0;
   }
 
-  // ═══════════════════════════════════════════════════════════════════════════
-  // MEMORY HELPERS
-  // ═══════════════════════════════════════════════════════════════════════════
+  async function loadMessagesInPreviousBucketTargetCount(
+    local: boolean,
+    key1: CellIdB64,
+    targetCount = TARGET_MESSAGES_COUNT,
+    bucketChunkSize = 3,
+    maxBucketsToFetch?: number,
+  ): Promise<number> {
+    console.group(`[MessageFlow][previousBucket] ${_cid(key1)}`);
+    console.log("local:", local);
 
-  /**
-   * Merge a batch of (older) messages into the in-memory store.
-   * Existing entries win (signal-first dedup).
-   * Refreshes the oldest-memory cursor after merging.
-   * Applies HARD_MEMORY_LIMIT eviction (oldest end) if needed.
-   *
-   * Returns the number of entries that were genuinely new to memory.
-   */
+    const memory = _getSortedMemoryEntries(key1);
+    const oldestMessage = memory[0]?.[1];
+
+    console.log(
+      "memory oldest:",
+      oldestMessage
+        ? {
+            timestamp: oldestMessage.timestamp,
+            bucket: oldestMessage.message.bucket,
+            hash: memory[0][0],
+          }
+        : null,
+    );
+
+    if (!oldestMessage) {
+      console.log("No oldest message in memory");
+      console.groupEnd();
+      return 0;
+    }
+
+    const oldestBucket = oldestMessage.message.bucket;
+    console.log("using oldest message.bucket:", oldestBucket);
+    console.log("requesting start bucket:", oldestBucket - 1);
+
+    if (oldestBucket <= 0) {
+      console.log("Already at earliest bucket");
+      console.groupEnd();
+      return 0;
+    }
+
+    const result = await _loadFromBucketPipeline(
+      local,
+      key1,
+      oldestBucket - 1,
+      targetCount,
+      bucketChunkSize,
+      maxBucketsToFetch,
+    );
+
+    console.log("result:", result);
+    console.groupEnd();
+    return result;
+  }
+
   function _mergeOlderIntoMemory(
     cellIdB64: CellIdB64,
     batch: [ActionHashB64, MessageExtended][],
@@ -359,30 +397,27 @@ export function createConversationMessageStore(
     if (batch.length === 0) return 0;
 
     let addedCount = 0;
+
     messages.update((m) => {
       const existing = m[cellIdB64] || {};
       const merged = { ...existing };
+
       for (const [hash, msg] of batch) {
         if (!(hash in merged)) {
           merged[hash] = msg;
           addedCount++;
         }
       }
+
       return { ...m, [cellIdB64]: merged };
     });
 
-    // Refresh cursor; then apply the hard cap (evicts oldest if over limit).
     _refreshOldestCursor(cellIdB64);
     _applyHardMemoryCap(cellIdB64);
 
     return addedCount;
   }
 
-  /**
-   * Insert a single newest-end message into memory.
-   * Does NOT update oldestMemoryTimestamp unless memory was empty.
-   * Does NOT trim — new signals and sent messages must always stay visible.
-   */
   function _insertNewestIntoMemory(
     cellIdB64: CellIdB64,
     hash: ActionHashB64,
@@ -390,54 +425,55 @@ export function createConversationMessageStore(
   ): void {
     messages.update((m) => {
       const existing = m[cellIdB64] || {};
-      if (hash in existing) return m; // already present
+      if (hash in existing) return m;
       return { ...m, [cellIdB64]: { ...existing, [hash]: msg } };
     });
 
-    // If this is the very first message in memory, initialise the cursor.
     paginationState.update((s) => {
       const cur = s[cellIdB64] ?? {
         oldestMemoryTimestamp: undefined,
         dbExhausted: false,
         networkExhausted: false,
       };
+
       if (cur.oldestMemoryTimestamp === undefined) {
-        return { ...s, [cellIdB64]: { ...cur, oldestMemoryTimestamp: msg.timestamp } };
+        return {
+          ...s,
+          [cellIdB64]: { ...cur, oldestMemoryTimestamp: msg.timestamp },
+        };
       }
+
       return s;
     });
   }
 
-  /**
-   * Recompute and persist the minimum timestamp across all in-memory messages.
-   * Must be called after any operation that may change the oldest end of memory.
-   */
   function _refreshOldestCursor(cellIdB64: CellIdB64): void {
     const mem = get(messages).data[cellIdB64] || {};
     const vals = Object.values(mem);
+
     if (vals.length === 0) {
       _setPaginationPartial(cellIdB64, { oldestMemoryTimestamp: undefined });
       return;
     }
+
     const oldest = Math.min(...vals.map((m) => m.timestamp));
     _setPaginationPartial(cellIdB64, { oldestMemoryTimestamp: oldest });
   }
 
-  /**
-   * Evict the oldest messages when memory exceeds HARD_MEMORY_LIMIT.
-   * Called only during scroll-up prepend; never during signal receipt.
-   * Keeps the HARD_MEMORY_LIMIT most-recent messages.
-   */
   function _applyHardMemoryCap(cellIdB64: CellIdB64): void {
     const mem = get(messages).data[cellIdB64] || {};
     const entries = Object.entries(mem);
+
     if (entries.length <= HARD_MEMORY_LIMIT) return;
 
-    // Sort newest-first, keep the head.
     const sorted = [...entries].sort(([, a], [, b]) => b.timestamp - a.timestamp);
     const kept = sorted.slice(0, HARD_MEMORY_LIMIT);
 
-    messages.update((m) => ({ ...m, [cellIdB64]: Object.fromEntries(kept) }));
+    messages.update((m) => ({
+      ...m,
+      [cellIdB64]: Object.fromEntries(kept),
+    }));
+
     _refreshOldestCursor(cellIdB64);
 
     _log("memory:hard-cap-applied", {
@@ -463,31 +499,22 @@ export function createConversationMessageStore(
     }));
   }
 
-  // ═══════════════════════════════════════════════════════════════════════════
-  // NETWORK BACKFILL  (scroll-up)
-  // ═══════════════════════════════════════════════════════════════════════════
-
-  /**
-   * Query Holochain for message hashes in buckets before cursorTimestamp,
-   * download entries that are missing from IndexedDB, store them.
-   * Does NOT update the in-memory store (caller does that via a DB query).
-   *
-   * Returns:
-   *   newlyStored    – count of messages newly written to IndexedDB
-   *   noMoreOnNetwork – true when Holochain returned 0 hashes for all queried buckets
-   */
   async function _backfillOlderMessagesToDB(
     cellIdB64: CellIdB64,
-    cursorTimestamp: number,
+    _cursorTimestamp: number,
   ): Promise<{ newlyStored: number; noMoreOnNetwork: boolean }> {
-    const oldestBucket = conversationStore.getBucket(cellIdB64, cursorTimestamp);
+    const oldestMessage = _getOldestMessage(cellIdB64);
+    if (!oldestMessage) {
+      return { newlyStored: 0, noMoreOnNetwork: true };
+    }
+
+    const oldestBucket = oldestMessage.message.bucket;
     if (oldestBucket <= 0) {
       return { newlyStored: 0, noMoreOnNetwork: true };
     }
 
     _log("backfill:start", { cell: _cid(cellIdB64), startBucket: oldestBucket - 1 });
 
-    // Fetch bucket hashes from Holochain (local DHT first to avoid slow network calls)
     const bucketsToFetch = await _fetchBucketsTargetCount(
       cellIdB64,
       oldestBucket - 1,
@@ -505,6 +532,7 @@ export function createConversationMessageStore(
     }
 
     const missingHashes = await _filterMissingHashesFromDB(allHashes);
+
     _log("backfill:missing-from-db", {
       cell: _cid(cellIdB64),
       total: allHashes.length,
@@ -512,8 +540,6 @@ export function createConversationMessageStore(
     });
 
     if (missingHashes.length === 0) {
-      // All hashes already in DB. Not network-exhausted — DB just has everything.
-      // The edge case (all in DB but wrong timestamps) is handled by the caller.
       return { newlyStored: 0, noMoreOnNetwork: false };
     }
 
@@ -521,15 +547,6 @@ export function createConversationMessageStore(
     return { newlyStored, noMoreOnNetwork: false };
   }
 
-  // ═══════════════════════════════════════════════════════════════════════════
-  // POLLING / BUCKET PIPELINE  (current bucket refresh)
-  // ═══════════════════════════════════════════════════════════════════════════
-
-  /**
-   * Fetch hashes from the current bucket range, download missing entries,
-   * store to DB, then hydrate the newest messages into memory.
-   * Used for initial load and ongoing polling — NOT for scroll-up.
-   */
   async function loadMessagesInCurrentBucketTargetCount(
     local: boolean,
     key1: CellIdB64,
@@ -538,34 +555,17 @@ export function createConversationMessageStore(
     maxBucketsToFetch?: number,
   ): Promise<number> {
     const bucket = conversationStore.getBucket(key1, Date.now());
+
     return _loadFromBucketPipeline(
-      local, key1, bucket, targetCount, bucketChunkSize, maxBucketsToFetch,
+      local,
+      key1,
+      bucket,
+      targetCount,
+      bucketChunkSize,
+      maxBucketsToFetch,
     );
   }
 
-  /**
-   * Same as above but starting from the bucket before the oldest in-memory message.
-   */
-  async function loadMessagesInPreviousBucketTargetCount(
-    local: boolean,
-    key1: CellIdB64,
-    targetCount = TARGET_MESSAGES_COUNT,
-    bucketChunkSize = 3,
-    maxBucketsToFetch?: number,
-  ): Promise<number> {
-    const cursor = get(paginationState)[key1]?.oldestMemoryTimestamp;
-    if (!cursor) return 0;
-    const oldestBucket = conversationStore.getBucket(key1, cursor);
-    return _loadFromBucketPipeline(
-      local, key1, oldestBucket - 1, targetCount, bucketChunkSize, maxBucketsToFetch,
-    );
-  }
-
-  /**
-   * Core bucket → hash → entry → DB → memory pipeline.
-   * Stores missing entries to DB, then hydrates the newest MESSAGES_PER_PAGE
-   * into memory using a signal-first merge.
-   */
   async function _loadFromBucketPipeline(
     local: boolean,
     key1: CellIdB64,
@@ -577,7 +577,12 @@ export function createConversationMessageStore(
     _log("pipeline:start", { cell: _cid(key1), local, bucket, targetCount });
 
     const bucketsToFetch = await _fetchBucketsTargetCount(
-      key1, bucket, local, targetCount, bucketChunkSize, maxBucketsToFetch,
+      key1,
+      bucket,
+      local,
+      targetCount,
+      bucketChunkSize,
+      maxBucketsToFetch,
     );
 
     const allHashes = flatten(bucketsToFetch.map((b) => b.actionHashB64s));
@@ -594,16 +599,11 @@ export function createConversationMessageStore(
     const stored = await _fetchAndStoreToDB(key1, missingHashes);
     _log("pipeline:stored", { cell: _cid(key1), stored });
 
-    // Hydrate the newest page into memory so new messages are immediately visible.
     await _hydrateNewestFromDB(key1);
 
     return stored;
   }
 
-  /**
-   * Read the newest MESSAGES_PER_PAGE messages from DB and merge them into
-   * memory using signal-first policy. Updates the oldest cursor.
-   */
   async function _hydrateNewestFromDB(cellIdB64: CellIdB64): Promise<void> {
     const dbMessages = await messageDB.getMessages(cellIdB64, MESSAGES_PER_PAGE);
     if (dbMessages.length === 0) return;
@@ -611,23 +611,22 @@ export function createConversationMessageStore(
     messages.update((m) => {
       const existing = m[cellIdB64] || {};
       const merged = { ...existing };
+
       for (const [hash, msg] of dbMessages) {
         if (!(hash in merged)) merged[hash] = msg;
       }
+
       return { ...m, [cellIdB64]: merged };
     });
 
     _refreshOldestCursor(cellIdB64);
+
     _log("db:hydrate-newest", {
       cell: _cid(cellIdB64),
       dbCount: dbMessages.length,
       memCount: Object.keys(get(messages).data[cellIdB64] || {}).length,
     });
   }
-
-  // ═══════════════════════════════════════════════════════════════════════════
-  // NETWORK PIPELINE HELPERS
-  // ═══════════════════════════════════════════════════════════════════════════
 
   async function _fetchBucketsTargetCount(
     key1: CellIdB64,
@@ -638,34 +637,46 @@ export function createConversationMessageStore(
     maxBucketsToFetch?: number,
   ): Promise<{ bucket: number; actionHashB64s: ActionHashB64[] }[]> {
     const cellId = decodeCellIdFromBase64(key1);
-    let bucketsToFetch: { bucket: number; actionHashB64s: ActionHashB64[] }[] = [];
+    const bucketsToFetch: { bucket: number; actionHashB64s: ActionHashB64[] }[] = [];
+
+    let currentBucket = bucket;
+    let fetchedBucketCount = 0;
+    let totalHashes = 0;
 
     while (
-      sum(bucketsToFetch.map(({ actionHashB64s }) => actionHashB64s.length)) <= targetCount &&
-      bucket >= 0 &&
-      (maxBucketsToFetch === undefined || bucketsToFetch.length <= maxBucketsToFetch)
+      totalHashes <= targetCount &&
+      currentBucket >= 0 &&
+      (maxBucketsToFetch === undefined || fetchedBucketCount < maxBucketsToFetch)
     ) {
-      const chunk = range(bucket, bucket - bucketChunkSize).filter((b) => b >= 0);
+      const chunkStart = currentBucket;
+      const chunkEnd = Math.max(0, currentBucket - bucketChunkSize + 1);
+      const chunk = range(chunkStart, chunkEnd - 1, -1);
+
       _log("pipeline:bucket-scan:chunk", { cell: _cid(key1), chunk, local });
 
-      bucketsToFetch = [
-        ...bucketsToFetch,
-        ...(await Promise.all(
-          chunk.map(async (b) => ({
+      const chunkResults = await Promise.all(
+        chunk.map(async (b) => {
+          const hashes = (
+            await client.getMessageHashes(cellId, { bucket: b, count: 0 }, local)
+          ).map(encodeHashToBase64);
+
+          return {
             bucket: b,
-            actionHashB64s: (
-              await client.getMessageHashes(cellId, { bucket: b, count: 0 }, local)
-            ).map(encodeHashToBase64),
-          })),
-        )),
-      ];
-      bucket -= 1;
+            actionHashB64s: hashes,
+          };
+        }),
+      );
+
+      bucketsToFetch.push(...chunkResults);
+      totalHashes = sum(bucketsToFetch.map(({ actionHashB64s }) => actionHashB64s.length));
+      fetchedBucketCount += chunkResults.length;
+      currentBucket = chunkEnd - 1;
     }
 
-    // Trim the last bucket if we already exceeded targetCount without it.
     while (
-      sum(bucketsToFetch.slice(0, -1).map(({ actionHashB64s }) => actionHashB64s.length)) >
-      targetCount
+      bucketsToFetch.length > 1 &&
+      sum(bucketsToFetch.slice(0, -1).map(({ actionHashB64s }) => actionHashB64s.length)) >=
+        targetCount
     ) {
       bucketsToFetch.pop();
     }
@@ -673,28 +684,27 @@ export function createConversationMessageStore(
     return bucketsToFetch;
   }
 
-  /**
-   * Parallel bulk-filter: return only the hashes not already in IndexedDB.
-   */
   async function _filterMissingHashesFromDB(
     actionHashB64s: ActionHashB64[],
   ): Promise<ActionHashB64[]> {
     if (actionHashB64s.length === 0) return [];
+
     const checks = await Promise.all(
-      actionHashB64s.map(async (h) => ({ h, exists: await messageDB.hasMessage(h) })),
+      actionHashB64s.map(async (h) => ({
+        h,
+        exists: await messageDB.hasMessage(h),
+      })),
     );
+
     return checks.filter((c) => !c.exists).map((c) => c.h);
   }
 
-  /**
-   * Fetch entries from Holochain, store them in IndexedDB.
-   * Does NOT update the in-memory store. Returns count of stored entries.
-   */
   async function _fetchAndStoreToDB(
     key1: CellIdB64,
     hashes: ActionHashB64[],
   ): Promise<number> {
     if (hashes.length === 0) return 0;
+
     _log("fetch-store:start", { cell: _cid(key1), hashes: hashes.length });
 
     const cellId = decodeCellIdFromBase64(key1);
@@ -703,6 +713,7 @@ export function createConversationMessageStore(
       hashes.map(decodeHashFromBase64),
       false,
     );
+
     _log("fetch-store:records", { cell: _cid(key1), fetched: records.length });
 
     const settled = await Promise.allSettled(
@@ -715,17 +726,20 @@ export function createConversationMessageStore(
       ),
     );
 
-    const valid = settled.filter((p) => p.status === "fulfilled").map((p) => p.value);
+    const valid = settled
+      .filter(
+        (p): p is PromiseFulfilledResult<[ActionHashB64, MessageExtended]> =>
+          p.status === "fulfilled",
+      )
+      .map((p) => p.value);
+
     if (valid.length === 0) return 0;
 
     await messageDB.storeMessages(key1, valid);
     _log("fetch-store:stored", { cell: _cid(key1), count: valid.length });
+
     return valid.length;
   }
-
-  // ═══════════════════════════════════════════════════════════════════════════
-  // SEND MESSAGE
-  // ═══════════════════════════════════════════════════════════════════════════
 
   async function sendMessage(key1: CellIdB64, content: string, files: LocalFile[]): Promise<void> {
     const cellId = decodeCellIdFromBase64(key1);
@@ -733,6 +747,7 @@ export function createConversationMessageStore(
     const messageFiles = await Promise.all(
       files.map(async (file) => {
         const entryHash = await fileStore.upload(key1, file.file);
+
         return {
           last_modified: file.file.lastModified,
           name: file.file.name,
@@ -771,13 +786,13 @@ export function createConversationMessageStore(
 
     const actionHashB64 = encodeHashToBase64(record.signed_action.hashed.hash);
 
-    // Persist first, then update memory.
     await messageDB.storeMessage(key1, actionHashB64, messageExtended);
     _insertNewestIntoMemory(key1, actionHashB64, messageExtended);
   }
 
   async function sendJoinNotice(key1: CellIdB64): Promise<void> {
     const cellId = decodeCellIdFromBase64(key1);
+
     let agentPubKeys;
     try {
       agentPubKeys = await client.getAgentsWithProfile(cellId);
@@ -805,13 +820,10 @@ export function createConversationMessageStore(
     });
 
     const actionHashB64 = encodeHashToBase64(record.signed_action.hashed.hash);
+
     await messageDB.storeMessage(key1, actionHashB64, messageExtended);
     _insertNewestIntoMemory(key1, actionHashB64, messageExtended);
   }
-
-  // ═══════════════════════════════════════════════════════════════════════════
-  // SIGNAL HANDLER
-  // ═══════════════════════════════════════════════════════════════════════════
 
   async function handleMessageSignalReceived(
     key1: CellIdB64,
@@ -819,12 +831,11 @@ export function createConversationMessageStore(
   ): Promise<void> {
     const actionHashB64 = encodeHashToBase64(signal.action.hashed.hash);
 
-    // DB dedup first (cheaper than making the MessageExtended)
     if (await messageDB.hasMessage(actionHashB64)) {
       _log("signal:dup-db", { cell: _cid(key1), hash: actionHashB64 });
       return;
     }
-    // Memory dedup (fast path for race conditions)
+
     if (actionHashB64 in (get(messages).data[key1] || {})) {
       _log("signal:dup-memory", { cell: _cid(key1), hash: actionHashB64 });
       return;
@@ -839,7 +850,6 @@ export function createConversationMessageStore(
     await messageDB.storeMessage(key1, actionHashB64, messageExtended);
     _insertNewestIntoMemory(key1, actionHashB64, messageExtended);
 
-    // Notification
     const mergedProfileContact = deriveCellMergedProfileContactInviteStore(
       mergedProfileContactInviteStore,
       key1,
@@ -849,12 +859,9 @@ export function createConversationMessageStore(
     _triggerMessageNotification(messageExtended, fromProfile);
   }
 
-  // ═══════════════════════════════════════════════════════════════════════════
-  // DELETE
-  // ═══════════════════════════════════════════════════════════════════════════
-
   async function deleteMessage(key1: CellIdB64, actionHashB64: ActionHashB64): Promise<void> {
     const cellId = decodeCellIdFromBase64(key1);
+
     const mergedProfileContact = deriveCellMergedProfileContactInviteStore(
       mergedProfileContactInviteStore,
       key1,
@@ -876,6 +883,7 @@ export function createConversationMessageStore(
     actionHashB64: ActionHashB64,
   ): Promise<void> {
     if (!(actionHashB64 in (get(messages).data[key1] || {}))) return;
+
     await messageDB.deleteMessage(actionHashB64);
     _removeFromMemory(key1, actionHashB64);
   }
@@ -886,20 +894,17 @@ export function createConversationMessageStore(
       delete copy[actionHashB64];
       return { ...m, [cellIdB64]: copy };
     });
-    // Cursor may have changed if we removed the oldest message.
+
     _refreshOldestCursor(cellIdB64);
   }
-
-  // ═══════════════════════════════════════════════════════════════════════════
-  // UTILITIES
-  // ═══════════════════════════════════════════════════════════════════════════
 
   async function _makeMessageExtended(
     cellId: CellId,
     messageRecord: MessageRecord,
   ): Promise<MessageExtended> {
-    if (!messageRecord.message)
+    if (!messageRecord.message) {
       throw new Error("MessageRecord does not include message entry");
+    }
 
     const base: MessageExtended = {
       message: messageRecord.message,
@@ -926,10 +931,12 @@ export function createConversationMessageStore(
     fromProfile?: ProfileExtended,
   ): Promise<void> {
     if (messageExtended.message.message_type === MessageType.System) return;
+
     const content =
       messageExtended.message.content.length > 125
         ? messageExtended.message.content.slice(0, 50) + "…"
         : messageExtended.message.content;
+
     await enqueueNotification(
       fromProfile ? `Message From ${fromProfile.profile.nickname}` : "New Message",
       content,
@@ -939,17 +946,15 @@ export function createConversationMessageStore(
   async function debugGetAllMessages(key1: CellIdB64): Promise<MessageRecord[]> {
     const bucket = conversationStore.getBucket(key1, Date.now());
     const cellId = decodeCellIdFromBase64(key1);
+
     const records = await client.getMessagesForBuckets(
       cellId,
       Array.from({ length: bucket + 1 }, (_, i) => i),
     );
+
     console.log("debugGetAllMessages records:", records);
     return records;
   }
-
-  // ═══════════════════════════════════════════════════════════════════════════
-  // PUBLIC INTERFACE
-  // ═══════════════════════════════════════════════════════════════════════════
 
   return {
     ...messages,
@@ -966,10 +971,6 @@ export function createConversationMessageStore(
     debugGetAllMessages,
   };
 }
-
-// ─────────────────────────────────────────────────────────────────────────────
-// CELL-SCOPED DERIVED STORE
-// ─────────────────────────────────────────────────────────────────────────────
 
 export interface CellConversationMessageStore
   extends GenericKeyValueStoreReadable<MessageExtended> {
@@ -990,21 +991,28 @@ export interface CellConversationMessageStore
   sendMessage: (content: string, files: LocalFile[]) => Promise<void>;
   sendJoinNotice: () => Promise<void>;
   handleMessageSignalReceived: (signal: MessageSignal) => Promise<void>;
-  debugGetAllMessages: () => Promise<HolochainRecord[]>;
+  deleteMessage: (key1: CellIdB64, actionHashB64: ActionHashB64) => Promise<void>;
+  debugGetAllMessages: () => Promise<MessageRecord[]>;
 }
 
 export function deriveCellConversationMessageStore(
   conversationMessageStore: ConversationMessageStore,
   key: CellIdB64,
-) {
-  // Canonical sort: ascending timestamp = oldest → newest (chronological).
-  // The UI receives this order directly; no .reverse() needed anywhere.
-  const data = deriveGenericKeyValueStore(conversationMessageStore, key, [
-    ([, m]) => m.timestamp,
-  ]);
+): CellConversationMessageStore {
+  const sorted = derived(conversationMessageStore, ($store) => {
+    const data = $store.data[key] || {};
+    const list = Object.entries(data).sort(([, a], [, b]) => a.timestamp - b.timestamp);
+
+    return {
+      data,
+      list,
+      count: list.length,
+    };
+  });
 
   return {
-    ...data,
+    subscribe: sorted.subscribe,
+    initialize: conversationMessageStore.initialize,
     loadMessagesInCurrentBucketTargetCount: (
       local: boolean,
       targetCount?: number,

--- a/ui/src/store/db/MessageDatabase.ts
+++ b/ui/src/store/db/MessageDatabase.ts
@@ -1,22 +1,19 @@
 import Dexie, { type Table } from "dexie";
 import type { CellIdB64, MessageExtended } from "$lib/types";
-import type { ActionHash } from "@holochain/client";
-import { encodeHashToBase64 } from "@holochain/client";
 
 // Type alias for encoded action hashes
 type ActionHashB64 = string;
 
 // Database schema for persistent message storage
 export interface DBMessage {
-  // id?: number; // Auto-increment primary key
-  actionHashB64: ActionHashB64; // Unique message identifier
-  cellIdB64: CellIdB64; // Conversation identifier
-  message: MessageExtended; // The actual message data
-  timestamp: number; // Message timestamp for sorting
-  bucket: number; // Message bucket for pagination
-  createdAt: number; // When this record was added to DB
-  deleted?: boolean; // Deletion tombstone to prevent reappearance
-  deletedAt?: number; // When the message was deleted
+  actionHashB64: ActionHashB64;
+  cellIdB64: CellIdB64;
+  message: MessageExtended;
+  timestamp: number;
+  bucket: number;
+  createdAt: number;
+  deleted?: boolean;
+  deletedAt?: number;
 }
 
 export class MessageDatabase extends Dexie {
@@ -25,10 +22,6 @@ export class MessageDatabase extends Dexie {
   constructor() {
     super("VollaMessagesDB");
 
-    // v1 used `++id` as the primary key. IndexedDB does not allow changing
-    // a store's keyPath in place, so switching to `actionHashB64` as the PK
-    // requires dropping and recreating the store. Cached messages are
-    // re-fetchable from the DHT, so the data loss on upgrade is acceptable.
     this.version(1).stores({
       messages:
         "++id, actionHashB64, cellIdB64, timestamp, bucket, [cellIdB64+timestamp], [cellIdB64+bucket]",
@@ -40,10 +33,6 @@ export class MessageDatabase extends Dexie {
     });
   }
 
-  /**
-   * Store a message in the database with error handling
-   * Added try-catch and quota handling
-   */
   async storeMessage(
     cellIdB64: CellIdB64,
     actionHashB64: ActionHashB64,
@@ -57,13 +46,13 @@ export class MessageDatabase extends Dexie {
         timestamp: messageExtended.timestamp,
         bucket: messageExtended.message.bucket,
         createdAt: Date.now(),
-        deleted: false, // Explicitly mark as not deleted
+        deleted: false,
       });
     } catch (error: any) {
-      if (error.name === 'QuotaExceededError') {
-        console.error('IndexedDB quota exceeded, attempting cleanup...');
+      if (error.name === "QuotaExceededError") {
+        console.error("IndexedDB quota exceeded, attempting cleanup...");
         await this.evictOldMessages(cellIdB64);
-        // Retry once after cleanup
+
         await this.messages.put({
           actionHashB64,
           cellIdB64,
@@ -74,37 +63,50 @@ export class MessageDatabase extends Dexie {
           deleted: false,
         });
       } else {
-        console.error('Failed to store message in IndexedDB:', error);
+        console.error("Failed to store message in IndexedDB:", error);
         throw error;
       }
     }
   }
 
-  /**
-   * Store multiple messages in the database 
-   */
   async storeMessages(
     cellIdB64: CellIdB64,
-    messages: Array<[ActionHashB64, MessageExtended]>,
+    entries: Array<[ActionHashB64, MessageExtended]>,
   ): Promise<void> {
     try {
-      const dbMessages = messages.map(([actionHashB64, messageExtended]) => ({
+      const dbRows = entries.map(([actionHashB64, messageExtended]) => ({
         actionHashB64,
         cellIdB64,
         message: messageExtended,
         timestamp: messageExtended.timestamp,
         bucket: messageExtended.message.bucket,
         createdAt: Date.now(),
-        deleted: false, // Explicitly mark as not deleted
+        deleted: false,
       }));
 
-      await this.messages.bulkPut(dbMessages);
+      console.group(`[MessageDB][storeMessages] ${cellIdB64.slice(0, 10)}`);
+      console.log("incoming count:", entries.length);
+      console.log(
+        "sample:",
+        entries.slice(0, 5).map(([hash, msg]) => ({
+          hash,
+          timestamp: msg.timestamp,
+          bucket: msg.message.bucket,
+          type: msg.message.message_type,
+        })),
+      );
+      console.groupEnd();
+
+      await this.messages.bulkPut(dbRows);
+
+      const storedCount = await this.messages.where("cellIdB64").equals(cellIdB64).count();
+      console.log("post-store total rows for cell:", storedCount);
     } catch (error: any) {
-      if (error.name === 'QuotaExceededError') {
-        console.error('IndexedDB quota exceeded during bulk insert, attempting cleanup...');
+      if (error.name === "QuotaExceededError") {
+        console.error("IndexedDB quota exceeded during bulk insert, attempting cleanup...");
         await this.evictOldMessages(cellIdB64);
-        // Retry once after cleanup
-        const dbMessages = messages.map(([actionHashB64, messageExtended]) => ({
+
+        const dbRows = entries.map(([actionHashB64, messageExtended]) => ({
           actionHashB64,
           cellIdB64,
           message: messageExtended,
@@ -113,253 +115,243 @@ export class MessageDatabase extends Dexie {
           createdAt: Date.now(),
           deleted: false,
         }));
-        await this.messages.bulkPut(dbMessages);
+
+        await this.messages.bulkPut(dbRows);
       } else {
-        console.error('Failed to bulk store messages in IndexedDB:', error);
+        console.error("Failed to bulk store messages in IndexedDB:", error);
         throw error;
       }
     }
   }
 
-  /**
-   * Get messages for a conversation with pagination
-   * Filter out deleted messages (tombstones)
-   */
   async getMessages(
     cellIdB64: CellIdB64,
     limit: number = 50,
     offset: number = 0,
   ): Promise<Array<[ActionHashB64, MessageExtended]>> {
-    const messages = await this.messages
+    const rows = await this.messages
       .where("[cellIdB64+timestamp]")
       .between([cellIdB64, Dexie.minKey], [cellIdB64, Dexie.maxKey])
-      .reverse() // Latest messages first
-      .filter(msg => !msg.deleted) // Filter out deleted messages
+      .reverse()
+      .filter((row) => !row.deleted)
       .offset(offset)
       .limit(limit)
       .toArray();
-    return messages.map((dbMessage) => [dbMessage.actionHashB64, dbMessage.message]);
+
+    console.group(`[MessageDB][getMessages] ${cellIdB64.slice(0, 10)}`);
+    console.log("limit:", limit, "offset:", offset);
+    console.log("result count:", rows.length);
+    console.log(
+      "sample:",
+      rows.slice(0, 5).map((row) => ({
+        hash: row.actionHashB64,
+        timestamp: row.timestamp,
+        bucket: row.bucket,
+      })),
+    );
+    console.groupEnd();
+
+    return rows.map((row) => [row.actionHashB64, row.message]);
   }
 
-  /**
-   * Get oldest messages for loading previous pages
-   * Filter out deleted messages (tombstones)
-   */
   async getOlderMessages(
     cellIdB64: CellIdB64,
     olderThanTimestamp: number,
     limit: number = 50,
   ): Promise<Array<[ActionHashB64, MessageExtended]>> {
-    const messages = await this.messages
+    console.group(`[MessageDB][getOlderMessages] ${cellIdB64.slice(0, 10)}`);
+    console.log("olderThanTimestamp:", olderThanTimestamp);
+    console.log("limit:", limit);
+
+    const rows = await this.messages
       .where("[cellIdB64+timestamp]")
       .between([cellIdB64, Dexie.minKey], [cellIdB64, olderThanTimestamp], false, false)
       .reverse()
-      .filter(msg => !msg.deleted) // Filter out deleted messages
+      .filter((row) => !row.deleted)
       .limit(limit)
       .toArray();
-    return messages.map((dbMessage) => [dbMessage.actionHashB64, dbMessage.message]);
+
+    console.log("result count:", rows.length);
+    console.log(
+      "result sample:",
+      rows.slice(0, 5).map((row) => ({
+        hash: row.actionHashB64,
+        timestamp: row.timestamp,
+        bucket: row.bucket,
+        deleted: row.deleted,
+      })),
+    );
+
+    if (rows.length === 0) {
+      const allRowsForCell = await this.messages
+        .where("[cellIdB64+timestamp]")
+        .between([cellIdB64, Dexie.minKey], [cellIdB64, Dexie.maxKey])
+        .filter((row) => !row.deleted)
+        .toArray();
+
+      console.log(
+        "db range:",
+        allRowsForCell.length > 0
+          ? {
+              count: allRowsForCell.length,
+              minTimestamp: Math.min(...allRowsForCell.map((row) => row.timestamp)),
+              maxTimestamp: Math.max(...allRowsForCell.map((row) => row.timestamp)),
+            }
+          : "no rows for cell",
+      );
+    }
+
+    console.groupEnd();
+
+    return rows.map((row) => [row.actionHashB64, row.message]);
   }
 
-  /**
-   * Check if a message exists in the database
-   */
   async hasMessage(actionHashB64: ActionHashB64): Promise<boolean> {
     const count = await this.messages.where("actionHashB64").equals(actionHashB64).count();
     return count > 0;
   }
 
-  /**
-   * Get the total count of messages for a conversation
-   */
   async getMessageCount(cellIdB64: CellIdB64): Promise<number> {
     return await this.messages.where("cellIdB64").equals(cellIdB64).count();
   }
 
-  /**
-   * Delete a message from the database using tombstone pattern
-   * Use tombstone instead of hard delete to prevent reappearance
-   */
   async deleteMessage(actionHashB64: ActionHashB64): Promise<void> {
     try {
-      const message = await this.messages.where("actionHashB64").equals(actionHashB64).first();
-      
-      if (message) {
-        // Mark as deleted (tombstone) instead of removing
+      const row = await this.messages.where("actionHashB64").equals(actionHashB64).first();
+
+      if (row) {
         await this.messages.put({
-          ...message,
+          ...row,
           deleted: true,
           deletedAt: Date.now(),
         });
         console.log(`Message ${actionHashB64} marked as deleted (tombstone)`);
       }
     } catch (error) {
-      console.error('Failed to delete message:', error);
+      console.error("Failed to delete message:", error);
       throw error;
     }
   }
 
-  /**
-   * Get the latest message for a conversation
-   * Filter out deleted messages
-   */
   async getLatestMessage(
     cellIdB64: CellIdB64,
   ): Promise<[ActionHashB64, MessageExtended] | undefined> {
-    const message = await this.messages
+    const row = await this.messages
       .where("[cellIdB64+timestamp]")
       .between([cellIdB64, Dexie.minKey], [cellIdB64, Dexie.maxKey])
       .reverse()
-      .filter(msg => !msg.deleted) // Filter out deleted messages
+      .filter((r) => !r.deleted)
       .first();
 
-    return message ? [message.actionHashB64, message.message] : undefined;
+    return row ? [row.actionHashB64, row.message] : undefined;
   }
 
-  /**
-   * Clear all messages for a conversation
-   */
   async clearConversationMessages(cellIdB64: CellIdB64): Promise<void> {
     await this.messages.where("cellIdB64").equals(cellIdB64).delete();
   }
 
-  /**
-   * Evict old messages when quota is exceeded
-   * Keeps most recent 1000 messages, removes older ones
-   */
   async evictOldMessages(cellIdB64: CellIdB64, keepCount: number = 1000): Promise<void> {
     try {
       console.log(`Evicting old messages for ${cellIdB64}, keeping ${keepCount} most recent`);
-      
-      // Get all messages for this conversation, sorted by timestamp (oldest first)
-      const allMessages = await this.messages
-        .where("cellIdB64")
-        .equals(cellIdB64)
-        .sortBy("timestamp");
-      
-      if (allMessages.length > keepCount) {
-        // Calculate how many to delete
-        const deleteCount = allMessages.length - keepCount;
-        const messagesToDelete = allMessages.slice(0, deleteCount);
-        
-        // Delete the oldest messages
-        const idsToDelete = messagesToDelete.map(msg => msg.actionHashB64).filter(id => id !== undefined);
+
+      const allRows = await this.messages.where("cellIdB64").equals(cellIdB64).sortBy("timestamp");
+
+      if (allRows.length > keepCount) {
+        const deleteCount = allRows.length - keepCount;
+        const rowsToDelete = allRows.slice(0, deleteCount);
+        const idsToDelete = rowsToDelete.map((row) => row.actionHashB64);
+
         await this.messages.bulkDelete(idsToDelete);
-        
         console.log(`Evicted ${deleteCount} old messages`);
       } else {
-        console.log(`No eviction needed, only ${allMessages.length} messages`);
+        console.log(`No eviction needed, only ${allRows.length} messages`);
       }
     } catch (error) {
-      console.error('Failed to evict old messages:', error);
-      // Don't throw - eviction failure shouldn't prevent message storage
+      console.error("Failed to evict old messages:", error);
     }
   }
 
-  /**
-   * Clean up old tombstones (deleted messages older than 30 days)
-   * This should be called periodically to free up space
-   */
   async cleanupOldTombstones(daysToKeep: number = 30): Promise<void> {
     try {
-      const cutoffTime = Date.now() - (daysToKeep * 24 * 60 * 60 * 1000);
-      
+      const cutoffTime = Date.now() - daysToKeep * 24 * 60 * 60 * 1000;
+
       const oldTombstones = await this.messages
-        .filter(msg => msg.deleted === true && (msg.deletedAt || 0) < cutoffTime)
+        .filter((row) => row.deleted === true && (row.deletedAt || 0) < cutoffTime)
         .toArray();
-      
+
       if (oldTombstones.length > 0) {
-        const idsToDelete = oldTombstones.map(msg => msg.actionHashB64).filter(id => id !== undefined);
+        const idsToDelete = oldTombstones.map((row) => row.actionHashB64);
         await this.messages.bulkDelete(idsToDelete);
         console.log(`Cleaned up ${oldTombstones.length} old tombstones`);
       }
     } catch (error) {
-      console.error('Failed to cleanup old tombstones:', error);
+      console.error("Failed to cleanup old tombstones:", error);
     }
   }
 
-  /**
-   * Debug utility: Get all unique Cell IDs stored in the database
-   */
   async getAllCellIds(): Promise<CellIdB64[]> {
-    const allMessages = await this.messages.toArray();
-    const uniqueCellIds = new Set(allMessages.map(msg => msg.cellIdB64));
+    const allRows = await this.messages.toArray();
+    const uniqueCellIds = new Set(allRows.map((row) => row.cellIdB64));
     return Array.from(uniqueCellIds);
   }
 
-  /**
-   * Debug utility: Get message count per Cell ID
-   */
   async getMessageCountPerCell(): Promise<Record<CellIdB64, number>> {
-    const allMessages = await this.messages.toArray();
+    const allRows = await this.messages.toArray();
     const counts: Record<CellIdB64, number> = {};
-    
-    allMessages.forEach(msg => {
-      if (!msg.deleted) {
-        counts[msg.cellIdB64] = (counts[msg.cellIdB64] || 0) + 1;
+
+    allRows.forEach((row) => {
+      if (!row.deleted) {
+        counts[row.cellIdB64] = (counts[row.cellIdB64] || 0) + 1;
       }
     });
-    
+
     return counts;
   }
 
-  /**
-   * Debug utility: Dump all database contents
-   */
   async debugDumpAll(): Promise<void> {
-    console.group(" IndexedDB Debug Dump");
-    
-    const allMessages = await this.messages.toArray();
-    console.log(`Total messages in DB: ${allMessages.length}`);
-    
+    console.group("IndexedDB Debug Dump");
+
+    const allRows = await this.messages.toArray();
+    console.log(`Total messages in DB: ${allRows.length}`);
+
     const cellIds = await this.getAllCellIds();
     console.log(`Unique Cell IDs: ${cellIds.length}`);
     cellIds.forEach((cellId, index) => {
       console.log(`  ${index + 1}. ${cellId}`);
     });
-    
+
     const counts = await this.getMessageCountPerCell();
     console.log("\nMessage counts per Cell ID:");
     Object.entries(counts).forEach(([cellId, count]) => {
       console.log(`  ${cellId.substring(0, 20)}...: ${count} messages`);
     });
-    
+
     console.groupEnd();
   }
 
-  /**
-   * Extract DNA Hash from Cell ID (first part before the agent pub key)
-   * Cell IDs are: DNAHash + AgentPubKey concatenated
-   */
   private extractDnaHash(cellIdB64: CellIdB64): string {
     return cellIdB64.substring(0, 52);
   }
 
-  /**
-   * Clear cache when agent changes (proper Holochain behavior)
-   * When a new agent appears with the same DNA, we clear the old agent's cache
-   * and let the new agent fetch their authorized messages from the DHT
-   */
-async clearCacheOnAgentChange(currentCellIdB64: CellIdB64): Promise<boolean> {
+  async clearCacheOnAgentChange(currentCellIdB64: CellIdB64): Promise<boolean> {
     const storedCellIds = await this.getAllCellIds();
-    
+
     if (storedCellIds.length === 0) {
-      // No stored messages, nothing to clear
       return false;
     }
-        
-    // Extract DNA hash from current Cell ID
+
     const currentDnaHash = this.extractDnaHash(currentCellIdB64);
-    
-    // Find stored Cell IDs with the same DNA hash but different agent
+
     const mismatchedCellIds = storedCellIds.filter(
-      storedCellId => this.extractDnaHash(storedCellId) === currentDnaHash && storedCellId !== currentCellIdB64
+      (storedCellId) =>
+        this.extractDnaHash(storedCellId) === currentDnaHash &&
+        storedCellId !== currentCellIdB64,
     );
-    
+
     if (mismatchedCellIds.length === 0) {
-      // No mismatched Cell IDs, this is either a new conversation or same agent
       return false;
     }
-    
+
     let totalCleared = 0;
     for (const oldCellId of mismatchedCellIds) {
       const count = await this.getMessageCount(oldCellId);
@@ -367,11 +359,10 @@ async clearCacheOnAgentChange(currentCellIdB64: CellIdB64): Promise<boolean> {
       totalCleared += count;
       console.log(`  Cleared ${count} messages from ${oldCellId.substring(0, 20)}...`);
     }
-    console.log(` Cache cleared: ${totalCleared} messages removed`);   
 
+    console.log(` Cache cleared: ${totalCleared} messages removed`);
     return true;
   }
 }
 
-// Singleton instance
 export const messageDB = new MessageDatabase();


### PR DESCRIPTION
### Summary
Resolves #141 #137 #118 
This change improves upward pagination in conversation history and prevents repeated top-scroll loading when the oldest available message has already been reached.

### TODO:
- added pagination exhaustion handling
- stopped repeated top-scroll triggers at history start
- improved anchor restoration after prepending messages
- refined previous-bucket loading based on oldest in-memory message
- integrated IndexedDB cache into history loading flow
- reduced duplicate Holochain fetches by checking cached hashes fir